### PR TITLE
Fix pod annotation, cert-name and add support for MutatingWebhookConfiguration

### DIFF
--- a/examples/operator/templates/mutating-webhook-configuration.yaml
+++ b/examples/operator/templates/mutating-webhook-configuration.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
+kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ include "operator.fullname" . }}-validating-webhook-configuration
+  name: {{ include "operator.fullname" . }}-mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "operator.fullname" . }}-serving-cert
   labels:
@@ -9,22 +9,21 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: '{{ include "operator.fullname" . }}-webhook-service'
       namespace: '{{ .Release.Namespace }}'
-      path: /validate-ceph-example-com-v1alpha1-volume
+      path: /mutate-ceph-example-com-v1-mycluster
   failurePolicy: Fail
-  name: vvolume.kb.io
+  name: mmycluster.kb.io
   rules:
   - apiGroups:
     - test.example.com
     apiVersions:
-    - v1alpha1
+    - v1
     operations:
     - CREATE
     - UPDATE
     resources:
-    - volumes
+    - myclusters
   sideEffects: None

--- a/go.mod
+++ b/go.mod
@@ -135,3 +135,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.11.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )
+
+replace github.com/arttor/helmify => github.com/yxd-ym/helmify main

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/arttor/helmify
 
+replace github.com/arttor/helmify => github.com/yxd-ym/helmify v0.3.6-0.20220118035442-54033b0e334b
+
 go 1.17
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/arttor/helmify
 
-replace github.com/arttor/helmify => github.com/yxd-ym/helmify v0.3.6-0.20220118035442-54033b0e334b
-
 go 1.17
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -135,5 +135,3 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.11.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )
-
-replace github.com/arttor/helmify => github.com/yxd-ym/helmify main

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -37,7 +37,7 @@ spec:
     metadata:
       labels:
 {{ .PodLabels }}
-{{- .PodAnnotations }}
+{{ .PodAnnotations }}
     spec:
 {{ .Spec }}`)
 

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -39,8 +39,7 @@ spec:
 {{ .PodLabels }}
 {{ .PodAnnotations }}
     spec:
-{{ .Spec }}
-`)
+{{ .Spec }}`)
 
 const selectorTempl = `%[1]s
 {{- include "%[2]s.selectorLabels" . | nindent 6 }}

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -37,7 +37,7 @@ spec:
     metadata:
       labels:
 {{ .PodLabels }}
-{{ .PodAnnotations }}
+{{- .PodAnnotations }}
     spec:
 {{ .Spec }}`)
 
@@ -102,6 +102,8 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 		if err != nil {
 			return true, nil, err
 		}
+
+		podAnnotations = "\n" + podAnnotations
 	}
 
 	nameCamel := strcase.ToLowerCamel(name)

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -39,7 +39,8 @@ spec:
 {{ .PodLabels }}
 {{ .PodAnnotations }}
     spec:
-{{ .Spec }}`)
+{{ .Spec }}
+`)
 
 const selectorTempl = `%[1]s
 {{- include "%[2]s.selectorLabels" . | nindent 6 }}

--- a/pkg/processor/webhook/mutating.go
+++ b/pkg/processor/webhook/mutating.go
@@ -66,26 +66,26 @@ func (w mwh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 	}
 	certName = strings.TrimPrefix(certName, appMeta.Namespace()+"/"+appMeta.ChartName()+"-")
 	res := fmt.Sprintf(mwhTempl, appMeta.ChartName(), name, certName, string(webhooks))
-	return true, &whResult{
+	return true, &mwhResult{
 		name: name,
 		data: []byte(res),
 	}, nil
 }
 
-type whResult struct {
+type mwhResult struct {
 	name string
 	data []byte
 }
 
-func (r *whResult) Filename() string {
+func (r *mwhResult) Filename() string {
 	return r.name + ".yaml"
 }
 
-func (r *whResult) Values() helmify.Values {
+func (r *mwhResult) Values() helmify.Values {
 	return helmify.Values{}
 }
 
-func (r *whResult) Write(writer io.Writer) error {
+func (r *mwhResult) Write(writer io.Writer) error {
 	_, err := writer.Write(r.data)
 	return err
 }

--- a/pkg/processor/webhook/mutating_test.go
+++ b/pkg/processor/webhook/mutating_test.go
@@ -1,0 +1,56 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/arttor/helmify/pkg/metadata"
+
+	"github.com/arttor/helmify/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+const mwhYaml = `apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: my-operator-system/my-operator-serving-cert
+  name: my-operator-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: my-operator-webhook-service
+      namespace: my-operator-system
+      path: /mutate-ceph-example-com-v1alpha1-volume
+  failurePolicy: Fail
+  name: vvolume.kb.io
+  rules:
+  - apiGroups:
+    - test.example.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - volumes
+  sideEffects: None`
+
+func Test_mwh_Process(t *testing.T) {
+	var testInstance mwh
+
+	t.Run("processed", func(t *testing.T) {
+		obj := internal.GenerateObj(mwhYaml)
+		processed, _, err := testInstance.Process(&metadata.Service{}, obj)
+		assert.NoError(t, err)
+		assert.Equal(t, true, processed)
+	})
+	t.Run("skipped", func(t *testing.T) {
+		obj := internal.TestNs
+		processed, _, err := testInstance.Process(&metadata.Service{}, obj)
+		assert.NoError(t, err)
+		assert.Equal(t, false, processed)
+	})
+}

--- a/pkg/processor/webhook/validating.go
+++ b/pkg/processor/webhook/validating.go
@@ -1,0 +1,91 @@
+package webhook
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/arttor/helmify/pkg/helmify"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	vwhTempl = `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "%[1]s.fullname" . }}-%[2]s
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "%[1]s.fullname" . }}-%[3]s
+  labels:
+  {{- include "%[1]s.labels" . | nindent 4 }}
+webhooks:
+%[4]s`
+)
+
+var vwhGVK = schema.GroupVersionKind{
+	Group:   "admissionregistration.k8s.io",
+	Version: "v1",
+	Kind:    "ValidatingWebhookConfiguration",
+}
+
+// ValidatingWebhook creates processor for k8s ValidatingWebhookConfiguration resource.
+func ValidatingWebhook() helmify.Processor {
+	return &vwh{}
+}
+
+type vwh struct{}
+
+// Process k8s ValidatingWebhookConfiguration object into template. Returns false if not capable of processing given resource type.
+func (w vwh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured) (bool, helmify.Template, error) {
+	if obj.GroupVersionKind() != vwhGVK {
+		return false, nil, nil
+	}
+	name := appMeta.TrimName(obj.GetName())
+
+	whConf := v1.ValidatingWebhookConfiguration{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &whConf)
+	if err != nil {
+		return true, nil, errors.Wrap(err, "unable to cast to ValidatingWebhookConfiguration")
+	}
+	for i, whc := range whConf.Webhooks {
+		whc.ClientConfig.Service.Name = appMeta.TemplatedName(whc.ClientConfig.Service.Name)
+		whc.ClientConfig.Service.Namespace = strings.ReplaceAll(whc.ClientConfig.Service.Namespace, appMeta.Namespace(), `{{ .Release.Namespace }}`)
+		whConf.Webhooks[i] = whc
+	}
+	webhooks, _ := yaml.Marshal(whConf.Webhooks)
+	webhooks = bytes.TrimRight(webhooks, "\n ")
+	certName, _, err := unstructured.NestedString(obj.Object, "metadata", "annotations", "cert-manager.io/inject-ca-from")
+	if err != nil {
+		return true, nil, errors.Wrap(err, "unable get webhook certName")
+	}
+	certName = strings.TrimPrefix(certName, appMeta.Namespace()+"/"+appMeta.ChartName()+"-")
+	res := fmt.Sprintf(vwhTempl, appMeta.ChartName(), name, certName, string(webhooks))
+	return true, &whResult{
+		name: name,
+		data: []byte(res),
+	}, nil
+}
+
+type vwhResult struct {
+	name string
+	data []byte
+}
+
+func (r *vwhResult) Filename() string {
+	return r.name + ".yaml"
+}
+
+func (r *vwhResult) Values() helmify.Values {
+	return helmify.Values{}
+}
+
+func (r *vwhResult) Write(writer io.Writer) error {
+	_, err := writer.Write(r.data)
+	return err
+}

--- a/pkg/processor/webhook/validating.go
+++ b/pkg/processor/webhook/validating.go
@@ -66,7 +66,7 @@ func (w vwh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 	}
 	certName = strings.TrimPrefix(certName, appMeta.Namespace()+"/"+appMeta.ChartName()+"-")
 	res := fmt.Sprintf(vwhTempl, appMeta.ChartName(), name, certName, string(webhooks))
-	return true, &whResult{
+	return true, &vwhResult{
 		name: name,
 		data: []byte(res),
 	}, nil

--- a/pkg/processor/webhook/validating_test.go
+++ b/pkg/processor/webhook/validating_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const whYaml = `apiVersion: admissionregistration.k8s.io/v1
+const vwhYaml = `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
@@ -38,11 +38,11 @@ webhooks:
     - volumes
   sideEffects: None`
 
-func Test_wh_Process(t *testing.T) {
-	var testInstance wh
+func Test_vwh_Process(t *testing.T) {
+	var testInstance vwh
 
 	t.Run("processed", func(t *testing.T) {
-		obj := internal.GenerateObj(whYaml)
+		obj := internal.GenerateObj(vwhYaml)
 		processed, _, err := testInstance.Process(&metadata.Service{}, obj)
 		assert.NoError(t, err)
 		assert.Equal(t, true, processed)

--- a/pkg/processor/webhook/webhook.go
+++ b/pkg/processor/webhook/webhook.go
@@ -64,7 +64,7 @@ func (w wh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured)
 	if err != nil {
 		return true, nil, errors.Wrap(err, "unable get webhook certName")
 	}
-	certName = strings.TrimPrefix(certName, appMeta.Namespace()+"/"+appMeta.Namespace()+"-")
+	certName = strings.TrimPrefix(certName, appMeta.Namespace()+"/"+appMeta.ChartName()+"-")
 	res := fmt.Sprintf(whTempl, appMeta.ChartName(), name, certName, string(webhooks))
 	return true, &whResult{
 		name: name,

--- a/pkg/processor/webhook/webhook.go
+++ b/pkg/processor/webhook/webhook.go
@@ -25,7 +25,8 @@ metadata:
   labels:
   {{- include "%[1]s.labels" . | nindent 4 }}
 webhooks:
-%[4]s`
+%[4]s
+`
 )
 
 var whGVK = schema.GroupVersionKind{

--- a/pkg/processor/webhook/webhook.go
+++ b/pkg/processor/webhook/webhook.go
@@ -25,8 +25,7 @@ metadata:
   labels:
   {{- include "%[1]s.labels" . | nindent 4 }}
 webhooks:
-%[4]s
-`
+%[4]s`
 )
 
 var whGVK = schema.GroupVersionKind{

--- a/test_data/k8s-operator-kustomize.output
+++ b/test_data/k8s-operator-kustomize.output
@@ -662,7 +662,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: my-operator-system/my-operator-serving-cert
+    cert-manager.io/inject-ca-from: my-operator-system/operator-serving-cert
   name: my-operator-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -724,3 +724,31 @@ spec:
     requests:
       storage: 2Gi
   storageClassName: cust1-mypool-lim
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: my-operator-system/operator-serving-cert
+  name: my-operator-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: my-operator-webhook-service
+      namespace: my-operator-system
+      path: /mutate-ceph-example-com-v1-mycluster
+  failurePolicy: Fail
+  name: mmycluster.kb.io
+  rules:
+  - apiGroups:
+    - test.example.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - myclusters
+  sideEffects: None


### PR DESCRIPTION
1. Preserve the line break before `annotation`.
2. Trim the prefix of cert-name properly.
3. Add support for MutatingWebhookConfiguration.