### PR TITLE
Update namespace in conversion webhook in CRD and template dnsName values.

### DIFF
--- a/examples/operator/templates/manifestcephvolume-crd.yaml
+++ b/examples/operator/templates/manifestcephvolume-crd.yaml
@@ -7,6 +7,16 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: '{{ include "operator.fullname" . }}-webhook-service'
+          namespace: '{{ .Release.Namespace }}'
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: test.example.com
   names:
     kind: ManifestCephVolume

--- a/examples/operator/templates/serving-cert.yaml
+++ b/examples/operator/templates/serving-cert.yaml
@@ -6,8 +6,8 @@ metadata:
   {{- include "operator.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - my-operator-webhook-service.{{ .Release.Namespace }}.svc
-  - my-operator-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  - '{{ include "operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'
+  - '{{ include "operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local'
   issuerRef:
     kind: Issuer
     name: '{{ include "operator.fullname" . }}-selfsigned-issuer'

--- a/pkg/helmify/model.go
+++ b/pkg/helmify/model.go
@@ -40,6 +40,8 @@ type AppMetadata interface {
 	//				"my-app-secret"		-> "{{ include "chart.fullname" . }}-secret"
 	//				etc...
 	TemplatedName(objName string) string
+	// TemplatedString converts a string to templated string with chart name.
+	TemplatedString(str string) string
 	// TrimName trims common prefix from object name if exists.
 	// We trim common prefix because helm already using release for this purpose.
 	TrimName(objName string) string

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -79,8 +79,7 @@ func (a *Service) ChartName() string {
 func (a *Service) TemplatedName(name string) string {
 	_, contains := a.names[name]
 	if !contains {
-		// template only app objects
-		return name
+		logrus.Warnf("Templating non-app object name: %s", name)
 	}
 	name = a.TrimName(name)
 	return fmt.Sprintf(nameTeml, a.chartName, name)

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -86,6 +86,11 @@ func (a *Service) TemplatedName(name string) string {
 	return fmt.Sprintf(nameTeml, a.chartName, name)
 }
 
+func (a *Service) TemplatedString(str string) string {
+	name := a.TrimName(str)
+	return fmt.Sprintf(nameTeml, a.chartName, name)
+}
+
 func extractAppNamespace(obj *unstructured.Unstructured) string {
 	if obj.GroupVersionKind() == nsGVK {
 		return obj.GetName()

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -79,7 +79,8 @@ func (a *Service) ChartName() string {
 func (a *Service) TemplatedName(name string) string {
 	_, contains := a.names[name]
 	if !contains {
-		logrus.Warnf("Templating non-app object name: %s", name)
+		// template only app objects
+		return name
 	}
 	name = a.TrimName(name)
 	return fmt.Sprintf(nameTeml, a.chartName, name)

--- a/pkg/processor/webhook/cert.go
+++ b/pkg/processor/webhook/cert.go
@@ -9,7 +9,6 @@ import (
 	"github.com/arttor/helmify/pkg/helmify"
 	yamlformat "github.com/arttor/helmify/pkg/yaml"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
@@ -54,11 +53,8 @@ func (c cert) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 	processedDnsNames := []interface{}{}
 	for _, dnsName := range dnsNames {
 		dns := dnsName.(string)
-		logrus.Infof("dns: %s", dns)
 		templatedDns := appMeta.TemplatedName(dns)
-		logrus.Infof("templatedDns: %s", templatedDns)
 		processedDns := strings.ReplaceAll(templatedDns, appMeta.Namespace(), "{{ .Release.Namespace }}")
-		logrus.Infof("processedDns: %s", processedDns)
 		processedDnsNames = append(processedDnsNames, processedDns)
 	}
 	err = unstructured.SetNestedSlice(obj.Object, processedDnsNames, "spec", "dnsNames")

--- a/pkg/processor/webhook/cert.go
+++ b/pkg/processor/webhook/cert.go
@@ -53,7 +53,7 @@ func (c cert) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 	processedDnsNames := []interface{}{}
 	for _, dnsName := range dnsNames {
 		dns := dnsName.(string)
-		templatedDns := appMeta.TemplatedName(dns)
+		templatedDns := appMeta.TemplatedString(dns)
 		processedDns := strings.ReplaceAll(templatedDns, appMeta.Namespace(), "{{ .Release.Namespace }}")
 		processedDnsNames = append(processedDnsNames, processedDns)
 	}

--- a/pkg/processor/webhook/cert.go
+++ b/pkg/processor/webhook/cert.go
@@ -49,12 +49,15 @@ func (c cert) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 	if err != nil {
 		return true, nil, errors.Wrap(err, "unable get cert dnsNames")
 	}
-	for i, dns := range dnsNames {
-		templatedDns := appMeta.TemplatedName(dns.(string))
+
+	processedDnsNames := []interface{}{}
+	for _, dnsName := range dnsNames {
+		dns := dnsName.(string)
+		templatedDns := appMeta.TemplatedName(dns)
 		processedDns := strings.ReplaceAll(templatedDns, appMeta.Namespace(), "{{ .Release.Namespace }}")
-		dnsNames[i] = processedDns
+		processedDnsNames = append(processedDnsNames, processedDns)
 	}
-	err = unstructured.SetNestedSlice(obj.Object, dnsNames, "spec", "dnsNames")
+	err = unstructured.SetNestedSlice(obj.Object, processedDnsNames, "spec", "dnsNames")
 	if err != nil {
 		return true, nil, errors.Wrap(err, "unable set cert dnsNames")
 	}

--- a/pkg/processor/webhook/cert.go
+++ b/pkg/processor/webhook/cert.go
@@ -50,9 +50,9 @@ func (c cert) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 		return true, nil, errors.Wrap(err, "unable get cert dnsNames")
 	}
 	for i, dns := range dnsNames {
-		dns = appMeta.TemplatedName(dns.(string))
-		dns = strings.ReplaceAll(dns.(string), appMeta.Namespace(), "{{ .Release.Namespace }}")
-		dnsNames[i] = dns
+		templatedDns := appMeta.TemplatedName(dns.(string))
+		processedDns := strings.ReplaceAll(templatedDns, appMeta.Namespace(), "{{ .Release.Namespace }}")
+		dnsNames[i] = processedDns
 	}
 	err = unstructured.SetNestedSlice(obj.Object, dnsNames, "spec", "dnsNames")
 	if err != nil {

--- a/pkg/processor/webhook/cert.go
+++ b/pkg/processor/webhook/cert.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arttor/helmify/pkg/helmify"
 	yamlformat "github.com/arttor/helmify/pkg/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
@@ -53,8 +54,11 @@ func (c cert) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 	processedDnsNames := []interface{}{}
 	for _, dnsName := range dnsNames {
 		dns := dnsName.(string)
+		logrus.Infof("dns: %s", dns)
 		templatedDns := appMeta.TemplatedName(dns)
+		logrus.Infof("templatedDns: %s", templatedDns)
 		processedDns := strings.ReplaceAll(templatedDns, appMeta.Namespace(), "{{ .Release.Namespace }}")
+		logrus.Infof("processedDns: %s", processedDns)
 		processedDnsNames = append(processedDnsNames, processedDns)
 	}
 	err = unstructured.SetNestedSlice(obj.Object, processedDnsNames, "spec", "dnsNames")

--- a/test_data/k8s-operator-kustomize.output
+++ b/test_data/k8s-operator-kustomize.output
@@ -232,6 +232,16 @@ metadata:
   creationTimestamp: null
   name: manifestcephvolumes.test.example.com
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: my-operator-webhook-service
+          namespace: my-operator-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: test.example.com
   names:
     kind: ManifestCephVolume


### PR DESCRIPTION
1. Add support to use template for conversion webhook in CRD.
2. Template dnsNames because they are assembled by kustomize.