### PR TITLE
feat: support statefulSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Usage:
 
 ## Status
 Supported k8s resources:
-- deployment
+- deployment, statefulset
 - service, Ingress
 - PersistentVolumeClaim
 - RBAC (serviceaccount, (cluster-)role, (cluster-)rolebinding)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arttor/helmify/pkg/processor/configmap"
 	"github.com/arttor/helmify/pkg/processor/crd"
 	"github.com/arttor/helmify/pkg/processor/deployment"
+	"github.com/arttor/helmify/pkg/processor/statefulset"
 	"github.com/arttor/helmify/pkg/processor/rbac"
 	"github.com/arttor/helmify/pkg/processor/secret"
 	"github.com/arttor/helmify/pkg/processor/service"
@@ -45,6 +46,7 @@ func Start(input io.Reader, config config.Config) error {
 		configmap.New(),
 		crd.New(),
 		deployment.New(),
+		statefulset.New(),
 		storage.New(),
 		service.New(),
 		service.NewIngress(),

--- a/pkg/processor/pod.go
+++ b/pkg/processor/pod.go
@@ -1,0 +1,201 @@
+package processor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arttor/helmify/pkg/helmify"
+	yamlformat "github.com/arttor/helmify/pkg/yaml"
+
+	"github.com/iancoleman/strcase"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type Pod struct {
+	Name    string
+	AppMeta helmify.AppMetadata
+	Pod     *corev1.PodTemplateSpec
+}
+
+func (p *Pod) ProcessSpec(values *helmify.Values) (string, error) {
+	podValues, err := p.getValues()
+	if err != nil {
+		return "", err
+	}
+	err = values.Merge(podValues)
+	if err != nil {
+		return "", err
+	}
+
+	template, err := p.template(values)
+	if err != nil {
+		return  "", err
+	}
+
+	return template, nil
+}
+
+func (p *Pod) ProcessObjectMeta() (string, string, error) {
+	podLabels, err := yamlformat.Marshal(p.Pod.ObjectMeta.Labels, 8)
+	if err != nil {
+		return "", "", err
+	}
+
+	podAnnotations := ""
+	if len(p.Pod.ObjectMeta.Annotations) != 0 {
+		podAnnotations, err = yamlformat.Marshal(map[string]interface{}{"annotations": p.Pod.ObjectMeta.Annotations}, 6)
+		if err != nil {
+			return "", "", err
+		}
+
+		podAnnotations = "\n" + podAnnotations
+	}
+
+	return podLabels, podAnnotations, nil
+}
+
+func (p *Pod) getValues() (helmify.Values, error) {
+	values := helmify.Values{}
+	for i, c := range p.Pod.Spec.Containers {
+		processed, err := p.processPodContainer(c, &values)
+		if err != nil {
+			return nil, err
+		}
+		p.Pod.Spec.Containers[i] = processed
+	}
+	for _, v := range p.Pod.Spec.Volumes {
+		if v.ConfigMap != nil {
+			v.ConfigMap.Name = p.AppMeta.TemplatedName(v.ConfigMap.Name)
+		}
+		if v.Secret != nil {
+			v.Secret.SecretName = p.AppMeta.TemplatedName(v.Secret.SecretName)
+		}
+	}
+	p.Pod.Spec.ServiceAccountName = p.AppMeta.TemplatedName(p.Pod.Spec.ServiceAccountName)
+
+	for i, s := range p.Pod.Spec.ImagePullSecrets {
+		p.Pod.Spec.ImagePullSecrets[i].Name = p.AppMeta.TemplatedName(s.Name)
+	}
+
+	return values, nil
+}
+
+func (p *Pod) processPodContainer(c corev1.Container, values *helmify.Values) (corev1.Container, error) {
+	index := strings.LastIndex(c.Image, ":")
+	if index < 0 {
+		return c, errors.New("wrong image format: " + c.Image)
+	}
+	repo, tag := c.Image[:index], c.Image[index+1:]
+	containerName := strcase.ToLowerCamel(c.Name)
+	c.Image = fmt.Sprintf("{{ .Values.%[1]s.%[2]s.image.repository }}:{{ .Values.%[1]s.%[2]s.image.tag | default .Chart.AppVersion }}", p.Name, containerName)
+
+	err := unstructured.SetNestedField(*values, repo, p.Name, containerName, "image", "repository")
+	if err != nil {
+		return c, errors.Wrap(err, "unable to set deployment value field")
+	}
+	err = unstructured.SetNestedField(*values, tag, p.Name, containerName, "image", "tag")
+	if err != nil {
+		return c, errors.Wrap(err, "unable to set deployment value field")
+	}
+	for _, e := range c.Env {
+		if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			e.ValueFrom.SecretKeyRef.Name = p.AppMeta.TemplatedName(e.ValueFrom.SecretKeyRef.Name)
+		}
+		if e.ValueFrom != nil && e.ValueFrom.ConfigMapKeyRef != nil {
+			e.ValueFrom.ConfigMapKeyRef.Name = p.AppMeta.TemplatedName(e.ValueFrom.ConfigMapKeyRef.Name)
+		}
+	}
+	for _, e := range c.EnvFrom {
+		if e.SecretRef != nil {
+			e.SecretRef.Name = p.AppMeta.TemplatedName(e.SecretRef.Name)
+		}
+		if e.ConfigMapRef != nil {
+			e.ConfigMapRef.Name = p.AppMeta.TemplatedName(e.ConfigMapRef.Name)
+		}
+	}
+	for k, v := range c.Resources.Requests {
+		err = unstructured.SetNestedField(*values, v.ToUnstructured(), p.Name, containerName, "resources", "requests", k.String())
+		if err != nil {
+			return c, errors.Wrap(err, "unable to set container resources value")
+		}
+	}
+	for k, v := range c.Resources.Limits {
+		err = unstructured.SetNestedField(*values, v.ToUnstructured(), p.Name, containerName, "resources", "limits", k.String())
+		if err != nil {
+			return c, errors.Wrap(err, "unable to set container resources value")
+		}
+	}
+	if len(c.Args) != 0 {
+		err = unstructured.SetNestedStringSlice(*values, c.Args, p.Name, containerName, "args")
+		if err != nil {
+			return c, errors.Wrap(err, "unable to set container resources value")
+		}
+	}
+	return c, nil
+}
+
+func (p *Pod) template(values *helmify.Values) (string, error) {
+	// replace PVC to templated name
+	for i := 0; i < len(p.Pod.Spec.Volumes); i++ {
+		vol := p.Pod.Spec.Volumes[i]
+		if vol.PersistentVolumeClaim == nil {
+			continue
+		}
+		tempPVCName := p.AppMeta.TemplatedName(vol.PersistentVolumeClaim.ClaimName)
+		p.Pod.Spec.Volumes[i].PersistentVolumeClaim.ClaimName = tempPVCName
+	}
+
+	// replace container resources with template to values.
+	specMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&p.Pod.Spec)
+	if err != nil {
+		return "", err
+	}
+	containers, _, err := unstructured.NestedSlice(specMap, "containers")
+	if err != nil {
+		return "", err
+	}
+	for i := range containers {
+		containerName := strcase.ToLowerCamel((containers[i].(map[string]interface{})["name"]).(string))
+		res, exists, err := unstructured.NestedMap(*values, p.Name, containerName, "resources")
+		if err != nil {
+			return "", err
+		}
+		if !exists || len(res) == 0 {
+			continue
+		}
+		err = unstructured.SetNestedField(containers[i].(map[string]interface{}), fmt.Sprintf(`{{- toYaml .Values.%s.%s.resources | nindent 10 }}`, p.Name, containerName), "resources")
+		if err != nil {
+			return "", err
+		}
+	}
+	for i := range containers {
+		containerName := strcase.ToLowerCamel((containers[i].(map[string]interface{})["name"]).(string))
+		res, exists, err := unstructured.NestedSlice(*values, p.Name, containerName, "args")
+		if err != nil {
+			return "", err
+		}
+		if !exists || len(res) == 0 {
+			continue
+		}
+		err = unstructured.SetNestedField(containers[i].(map[string]interface{}), fmt.Sprintf(`{{- toYaml .Values.%s.%s.args | nindent 10 }}`, p.Name, containerName), "args")
+		if err != nil {
+			return "", err
+		}
+	}
+	err = unstructured.SetNestedSlice(specMap, containers, "containers")
+	if err != nil {
+		return "", err
+	}
+
+	spec, err := yamlformat.Marshal(specMap, 6)
+	if err != nil {
+		return "", err
+	}
+	spec = strings.ReplaceAll(spec, "'", "")
+
+	return spec, nil
+}

--- a/pkg/processor/statefulset/statefulset.go
+++ b/pkg/processor/statefulset/statefulset.go
@@ -1,4 +1,4 @@
-package deployment
+package statefulset
 
 import (
 	"fmt"
@@ -17,13 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var deploymentGVC = schema.GroupVersionKind{
+var statefulsetGVC = schema.GroupVersionKind{
 	Group:   "apps",
 	Version: "v1",
-	Kind:    "Deployment",
+	Kind:    "StatefulSet",
 }
 
-var deploymentTempl, _ = template.New("deployment").Parse(
+var statefulsetTempl, _ = template.New("statefulset").Parse(
 	`{{- .Meta }}
 spec:
 {{- if .Replicas }}
@@ -39,22 +39,22 @@ spec:
     spec:
 {{ .Spec }}`)
 
-// New creates processor for k8s Deployment resource.
+// New creates processor for k8s StatefulSet resource.
 func New() helmify.Processor {
-	return &deployment{}
+	return &statefulset{}
 }
 
-type deployment struct{}
+type statefulset struct{}
 
-// Process k8s Deployment object into template. Returns false if not capable of processing given resource type.
-func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured) (bool, helmify.Template, error) {
-	if obj.GroupVersionKind() != deploymentGVC {
+// Process k8s StatefulSet object into template. Returns false if not capable of processing given resource type.
+func (d statefulset) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured) (bool, helmify.Template, error) {
+	if obj.GroupVersionKind() != statefulsetGVC {
 		return false, nil, nil
 	}
-	typedObj := appsv1.Deployment{}
+	typedObj := appsv1.StatefulSet{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &typedObj)
 	if err != nil {
-		return true, nil, errors.Wrap(err, "unable to cast to deployment")
+		return true, nil, errors.Wrap(err, "unable to cast to statefulset")
 	}
 
 	values := helmify.Values{}
@@ -126,7 +126,7 @@ type result struct {
 }
 
 func (r *result) Filename() string {
-	return "deployment.yaml"
+	return "statefulset.yaml"
 }
 
 func (r *result) Values() helmify.Values {
@@ -134,5 +134,5 @@ func (r *result) Values() helmify.Values {
 }
 
 func (r *result) Write(writer io.Writer) error {
-	return deploymentTempl.Execute(writer, r.data)
+	return statefulsetTempl.Execute(writer, r.data)
 }

--- a/pkg/processor/util.go
+++ b/pkg/processor/util.go
@@ -1,0 +1,76 @@
+package processor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arttor/helmify/pkg/helmify"
+	yamlformat "github.com/arttor/helmify/pkg/yaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ReplicaTyped struct {
+	Spec ReplicaTypedSpec
+}
+
+type ReplicaTypedSpec struct {
+	Replicas *int32
+}
+
+func ProcessReplicas(name string, r *int32, values *helmify.Values) (string, error) {
+	obj := ReplicaTyped{
+		Spec: ReplicaTypedSpec{
+			Replicas: r,
+		},
+	}
+	if obj.Spec.Replicas == nil {
+		return "", nil
+	}
+	replicasTpl, err := values.Add(int64(*obj.Spec.Replicas), name, "replicas")
+	if err != nil {
+		return "", err
+	}
+	replicas, err := yamlformat.Marshal(map[string]interface{}{"replicas": replicasTpl}, 2)
+	if err != nil {
+		return "", err
+	}
+	replicas = strings.ReplaceAll(replicas, "'", "")
+	return replicas, nil
+}
+
+type SelectorTyped struct {
+	Spec SelectorTypedSpec
+}
+
+type SelectorTypedSpec struct {
+	Selector *metav1.LabelSelector
+}
+
+const selectorTempl = `%[1]s
+{{- include "%[2]s.selectorLabels" . | nindent 6 }}
+%[3]s`
+
+func ProcessSelector(appMeta helmify.AppMetadata, s *metav1.LabelSelector) (string, error) {
+	obj := SelectorTyped{
+		Spec: SelectorTypedSpec{
+			Selector: s,
+		},
+	}
+	matchLabels, err := yamlformat.Marshal(map[string]interface{}{"matchLabels": obj.Spec.Selector.MatchLabels}, 0)
+	if err != nil {
+		return "", err
+	}
+	matchExpr := ""
+	if obj.Spec.Selector.MatchExpressions != nil {
+		matchExpr, err = yamlformat.Marshal(map[string]interface{}{"matchExpressions": obj.Spec.Selector.MatchExpressions}, 0)
+		if err != nil {
+			return "", err
+		}
+	}
+	selector := fmt.Sprintf(selectorTempl, matchLabels, appMeta.ChartName(), matchExpr)
+	selector = strings.Trim(selector, " \n")
+	selector = string(yamlformat.Indent([]byte(selector), 4))
+
+	return selector, nil
+}


### PR DESCRIPTION
This PR implements support for StatefulSets, which is pretty much the same as Deployments.
To facilitate this I've abstracted out the processing of Deployment into logical functions
so that both the StatefulSet and Deployment can use them.

I've also hitched a small feature along with this change: templating Args into Values.