### PR TITLE
Support custom cluster domain

### DIFF
--- a/examples/app/templates/deployment.yaml
+++ b/examples/app/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
             secretKeyRef:
               key: VAR2
               name: {{ include "app.fullname" . }}-secret-vars
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ .Values.kubernetesClusterDomain }}
         image: {{ .Values.app.app.image.repository }}:{{ .Values.app.app.image.tag | default
           .Chart.AppVersion }}
         livenessProbe:
@@ -69,6 +71,9 @@ spec:
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --v=10
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ .Values.kubernetesClusterDomain }}
         image: {{ .Values.app.proxySidecar.image.repository }}:{{ .Values.app.proxySidecar.image.tag
           | default .Chart.AppVersion }}
         name: proxy-sidecar

--- a/examples/app/values.yaml
+++ b/examples/app/values.yaml
@@ -37,6 +37,7 @@ configProps:
   myProp1: "1"
   myProp2: val 1
   myProp3: "true"
+kubernetesClusterDomain: cluster.local
 pvc:
   samplePvClaim:
     storageClass: manual

--- a/examples/operator/templates/deployment.yaml
+++ b/examples/operator/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.kubeRbacProxy.image.repository }}:{{ .Values.controllerManager.kubeRbacProxy.image.tag
           | default .Chart.AppVersion }}
         name: kube-rbac-proxy
@@ -49,6 +52,8 @@ spec:
             secretKeyRef:
               key: VAR1
               name: {{ include "operator.fullname" . }}-secret-vars
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
           | default .Chart.AppVersion }}
         livenessProbe:

--- a/examples/operator/templates/serving-cert.yaml
+++ b/examples/operator/templates/serving-cert.yaml
@@ -7,7 +7,8 @@ metadata:
 spec:
   dnsNames:
   - '{{ include "operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'
-  - '{{ include "operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local'
+  - '{{ include "operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{
+    .Values.kubernetesClusterDomain }}'
   issuerRef:
     kind: Issuer
     name: '{{ include "operator.fullname" . }}-selfsigned-issuer'

--- a/examples/operator/values.yaml
+++ b/examples/operator/values.yaml
@@ -15,6 +15,7 @@ controllerManager:
         cpu: 100m
         memory: 20Mi
   replicas: 1
+kubernetesClusterDomain: cluster.local
 managerConfig:
   controllerManagerConfigYaml:
     health:

--- a/pkg/cluster/domain.go
+++ b/pkg/cluster/domain.go
@@ -1,0 +1,7 @@
+package cluster
+
+const (
+	DefaultDomain = "cluster.local"
+	DomainKey     = "kubernetesClusterDomain"
+	DomainEnv     = "KUBERNETES_CLUSTER_DOMAIN"
+)

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/arttor/helmify/pkg/cluster"
 	"github.com/arttor/helmify/pkg/helmify"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -35,6 +36,7 @@ func (o output) Create(chartDir, chartName string, templates []helmify.Template)
 	// group templates into files
 	files := map[string][]helmify.Template{}
 	values := helmify.Values{}
+	values[cluster.DomainKey] = cluster.DefaultDomain
 	for _, template := range templates {
 		file := files[template.Filename()]
 		file = append(file, template)

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/arttor/helmify/pkg/cluster"
 	"github.com/arttor/helmify/pkg/processor"
 
 	"github.com/arttor/helmify/pkg/helmify"
@@ -254,6 +255,10 @@ func processPodContainer(name string, appMeta helmify.AppMetadata, c corev1.Cont
 			e.ConfigMapRef.Name = appMeta.TemplatedName(e.ConfigMapRef.Name)
 		}
 	}
+	c.Env = append(c.Env, corev1.EnvVar{
+		Name:  cluster.DomainEnv,
+		Value: fmt.Sprintf("{{ .Values.%s }}", cluster.DomainKey),
+	})
 	for k, v := range c.Resources.Requests {
 		err = unstructured.SetNestedField(*values, v.ToUnstructured(), name, containerName, "resources", "requests", k.String())
 		if err != nil {

--- a/pkg/processor/webhook/cert.go
+++ b/pkg/processor/webhook/cert.go
@@ -6,17 +6,13 @@ import (
 	"io"
 	"strings"
 
+	"github.com/arttor/helmify/pkg/cluster"
 	"github.com/arttor/helmify/pkg/helmify"
 	yamlformat "github.com/arttor/helmify/pkg/yaml"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
-)
-
-const (
-	defaultClusterDomain   = "cluster.local"
-	valuesClusterDomainKey = "kubernetesClusterDomain"
 )
 
 const (
@@ -60,7 +56,7 @@ func (c cert) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 		dns := dnsName.(string)
 		templatedDns := appMeta.TemplatedString(dns)
 		processedDns := strings.ReplaceAll(templatedDns, appMeta.Namespace(), "{{ .Release.Namespace }}")
-		processedDns = strings.ReplaceAll(processedDns, defaultClusterDomain, fmt.Sprintf("{{ .Values.%s }}", valuesClusterDomainKey))
+		processedDns = strings.ReplaceAll(processedDns, cluster.DefaultDomain, fmt.Sprintf("{{ .Values.%s }}", cluster.DomainKey))
 		processedDnsNames = append(processedDnsNames, processedDns)
 	}
 	err = unstructured.SetNestedSlice(obj.Object, processedDnsNames, "spec", "dnsNames")
@@ -85,7 +81,7 @@ func (c cert) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 		name: name,
 		data: []byte(res),
 		values: helmify.Values{
-			valuesClusterDomainKey: defaultClusterDomain,
+			cluster.DomainKey: cluster.DefaultDomain,
 		},
 	}, nil
 }

--- a/pkg/processor/webhook/cert.go
+++ b/pkg/processor/webhook/cert.go
@@ -80,16 +80,12 @@ func (c cert) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 	return true, &certResult{
 		name: name,
 		data: []byte(res),
-		values: helmify.Values{
-			cluster.DomainKey: cluster.DefaultDomain,
-		},
 	}, nil
 }
 
 type certResult struct {
-	name   string
-	data   []byte
-	values helmify.Values
+	name string
+	data []byte
 }
 
 func (r *certResult) Filename() string {
@@ -97,7 +93,7 @@ func (r *certResult) Filename() string {
 }
 
 func (r *certResult) Values() helmify.Values {
-	return r.values
+	return helmify.Values{}
 }
 
 func (r *certResult) Write(writer io.Writer) error {


### PR DESCRIPTION
Some kubernetes clusters have cluster domain not being `cluster.local`. Make the generated chart to be able to customize this value.