### PR TITLE
Apply Source CRD labels to CRDs Templates

### DIFF
--- a/examples/operator/templates/cephvolume-crd.yaml
+++ b/examples/operator/templates/cephvolume-crd.yaml
@@ -4,8 +4,8 @@ metadata:
   name: cephvolumes.test.example.com
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "operator.fullname" . }}-serving-cert
-    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
+    example-label: my-app
   {{- include "operator.labels" . | nindent 4 }}
 spec:
   group: test.example.com

--- a/examples/operator/templates/manifestcephvolume-crd.yaml
+++ b/examples/operator/templates/manifestcephvolume-crd.yaml
@@ -4,8 +4,8 @@ metadata:
   name: manifestcephvolumes.test.example.com
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "operator.fullname" . }}-serving-cert
-    controller-gen.kubebuilder.io/version: v0.7.0
   labels:
+
   {{- include "operator.labels" . | nindent 4 }}
 spec:
   conversion:

--- a/pkg/processor/crd/crd_test.go
+++ b/pkg/processor/crd/crd_test.go
@@ -15,9 +15,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: my-operator-system/my-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: cephvolumes.test.example.com
+  labels:
+    example: true
 spec:
   group: test.example.com
   names:

--- a/test_data/k8s-operator-kustomize.output
+++ b/test_data/k8s-operator-kustomize.output
@@ -10,9 +10,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: my-operator-system/operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: cephvolumes.test.example.com
+  labels:
+    example-label: my-app 
 spec:
   group: test.example.com
   names:
@@ -230,7 +231,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: my-operator-system/operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: manifestcephvolumes.test.example.com
 spec:


### PR DESCRIPTION
This change adds any labels present on the source CRD to the generated CRD template. This is useful for preserving any labels which were generated before calling helmify, eg during the kustomize phase.

Also removed hardcoded instances of `controller-gen.kubebuilder.io/version: v0.7.0` from the annotations section.
Also renamed `versions` variable to `specYaml` for clarity.