### PR TITLE
Support creating a helm template for an object with only helm labels

### DIFF
--- a/pkg/processor/meta.go
+++ b/pkg/processor/meta.go
@@ -31,9 +31,13 @@ func ProcessObjMeta(appMeta helmify.AppMetadata, obj *unstructured.Unstructured)
 		delete(l, "app.kubernetes.io/version")
 		delete(l, "app.kubernetes.io/managed-by")
 		delete(l, "helm.sh/chart")
-		labels, err = yamlformat.Marshal(l, 4)
-		if err != nil {
-			return "", err
+
+		// Since we delete labels above, it is possible that at this point there are no more labels.
+		if len(l) > 0 {
+			labels, err = yamlformat.Marshal(l, 4)
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 	if len(obj.GetAnnotations()) != 0 {


### PR DESCRIPTION
I ran into the issue where I have a deployment that specifcies only `app.kubernetes.io/name` as a label, which results in the creation of an invalid helm template.

Input:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: controller-manager
  namespace: system
  labels:
    app.kubernetes.io/name: operator
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: operator
  replicas: 1
  template:
    metadata:
      labels:
        app.kubernetes.io/name: value
      annotations:
        kubectl.kubernetes.io/default-container: manager
    spec:
      securityContext:
        runAsNonRoot: true
      containers:
      - command:
        - /operator
        args:
        - operator
        - --leader-elect
        image: controller:latest
        imagePullPolicy: IfNotPresent
        name: manager
      serviceAccountName: controller-manager
      terminationGracePeriodSeconds: 10
```

The resulting bit in the helm template is:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: {{ include "chart.fullname" . }}-controller-manager
  labels:
    {} # <-- this is invalid
  {{- include "chart.labels" . | nindent 4 }}
spec:
  replicas: {{ .Values.controllerManager.replicas }}
  selector:
```

This PR makes sure that such cases are handled properly and do not result in an invalid helm template