### PR TITLE
lint: remove deprecated io/ioutils pkg references

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -1,7 +1,6 @@
 package helm
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +104,7 @@ func overwriteValuesFile(chartDir string, values helmify.Values) error {
 		return errors.Wrap(err, "unable to write marshal values.yaml")
 	}
 	file := filepath.Join(chartDir, "values.yaml")
-	err = ioutil.WriteFile(file, res, 0600)
+	err = os.WriteFile(file, res, 0600)
 	if err != nil {
 		return errors.Wrap(err, "unable to write values.yaml")
 	}

--- a/pkg/helm/init.go
+++ b/pkg/helm/init.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -170,7 +169,7 @@ func createCommonFiles(chartDir, chartName string, crd bool) error {
 			return
 		}
 		file := filepath.Join(path...)
-		err = ioutil.WriteFile(file, content, 0750)
+		err = os.WriteFile(file, content, 0750)
 		if err == nil {
 			logrus.WithField("file", file).Info("created")
 		}


### PR DESCRIPTION
- Remove deprecated io/ioutils pkg references