### PR TITLE
Update the file's permission

### DIFF
--- a/pkg/helm/init.go
+++ b/pkg/helm/init.go
@@ -170,7 +170,7 @@ func createCommonFiles(chartDir, chartName string, crd bool) error {
 			return
 		}
 		file := filepath.Join(path...)
-		err = ioutil.WriteFile(file, content, 0750)
+		err = ioutil.WriteFile(file, content, 0640)
 		if err == nil {
 			logrus.WithField("file", file).Info("created")
 		}


### PR DESCRIPTION
While using the `helmify`, the autogenerated files have executable attributes like `Chart.yaml` and `_helpers.tql`, etc. However, there is no need for these files to execute and the pr can fix it. 