### PR TITLE
minimal implementation for imagePullSecrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ Usage:
 | -version | Print helmify version.                                                                                                                                                                                      | `helmify -version`|
 | -crd-dir | Place crds in their own folder per Helm 3 [docs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you). Caveat: CRDs templating is not supported by Helm. | `helmify -crd-dir`|
 
+## ImagePullSecrets
+
+If no `imagePullSecrets` are present in the input manifests, helmify allows existing 
+secrets to be used as `imagePullSecrets` for pods in deployments and daemonsets.
+
+This is opt-in, there is a comment in `values.yaml` about how this can be enabled.
+
+```yaml
+# values.yaml
+imagePullSecrets:
+- name: image-pull-secret
+```
+
 ## Status
 Supported k8s resources:
 - deployment

--- a/README.md
+++ b/README.md
@@ -74,21 +74,7 @@ Usage:
 | -vv | Enable very verbose output. Also prints DEBUG.                                                                                                                                                              | `helmify -vv`|
 | -version | Print helmify version.                                                                                                                                                                                      | `helmify -version`|
 | -crd-dir | Place crds in their own folder per Helm 3 [docs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you). Caveat: CRDs templating is not supported by Helm. | `helmify -crd-dir`|
-| -image-pull-secrets| Allows the user to use existing secrets as imagePullSecrets | `helmify -image-pull-secrets`|
-
-## ImagePullSecrets
-
-If no `imagePullSecrets` are present in the input manifests, helmify allows existing 
-secrets to be used as `imagePullSecrets` for pods in deployments and daemonsets.
-
-You need to enable this feature by the `-image-pull-secrets` flag. This allows
-the user to add existing secrets in `values.yaml` like:
-
-```yaml
-# values.yaml
-imagePullSecrets:
-- name: image-pull-secret
-```
+| -image-pull-secrets| Allows the user to use existing secrets as imagePullSecrets  | `helmify -image-pull-secrets`|
 
 ## Status
 Supported k8s resources:

--- a/README.md
+++ b/README.md
@@ -74,13 +74,15 @@ Usage:
 | -vv | Enable very verbose output. Also prints DEBUG.                                                                                                                                                              | `helmify -vv`|
 | -version | Print helmify version.                                                                                                                                                                                      | `helmify -version`|
 | -crd-dir | Place crds in their own folder per Helm 3 [docs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you). Caveat: CRDs templating is not supported by Helm. | `helmify -crd-dir`|
+| -image-pull-secrets| Allows the user to use existing secrets as imagePullSecrets | `helmify -image-pull-secrets`|
 
 ## ImagePullSecrets
 
 If no `imagePullSecrets` are present in the input manifests, helmify allows existing 
 secrets to be used as `imagePullSecrets` for pods in deployments and daemonsets.
 
-This is opt-in, in `values.yaml` you can add secrets like:
+You need to enable this feature by the `-image-pull-secrets` flag. This allows
+the user to add existing secrets in `values.yaml` like:
 
 ```yaml
 # values.yaml

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Usage:
 If no `imagePullSecrets` are present in the input manifests, helmify allows existing 
 secrets to be used as `imagePullSecrets` for pods in deployments and daemonsets.
 
-This is opt-in, there is a comment in `values.yaml` about how this can be enabled.
+This is opt-in, in `values.yaml` you can add secrets like:
 
 ```yaml
 # values.yaml

--- a/cmd/helmify/flags.go
+++ b/cmd/helmify/flags.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 
 	"github.com/arttor/helmify/pkg/config"
-	"github.com/arttor/helmify/pkg/processor/imagePullSecrets"
 )
 
 const helpText = `Helmify parses kubernetes resources from std.in and converts it to a Helm chart.
@@ -37,7 +36,7 @@ func ReadFlags() config.Config {
 	flag.BoolVar(&result.Verbose, "v", false, "Enable verbose output (print WARN & INFO). Example: helmify -v")
 	flag.BoolVar(&result.VeryVerbose, "vv", false, "Enable very verbose output. Same as verbose but with DEBUG. Example: helmify -vv")
 	flag.BoolVar(&crd, "crd-dir", false, "Enable crd install into 'crds' directory.\nWarning: CRDs placed in 'crds' directory will not be templated by Helm.\nSee https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations\nExample: helmify -crd-dir")
-	flag.BoolVar(&imagePullSecrets.Enabled, "image-pull-secrets", false, "Allows the user to use existing secrets as imagePullSecrets in values.yaml")
+	flag.BoolVar(&result.ImagePullSecrets, "image-pull-secrets", false, "Allows the user to use existing secrets as imagePullSecrets in values.yaml")
 
 	flag.Parse()
 	if h || help {

--- a/cmd/helmify/flags.go
+++ b/cmd/helmify/flags.go
@@ -37,7 +37,7 @@ func ReadFlags() config.Config {
 	flag.BoolVar(&result.Verbose, "v", false, "Enable verbose output (print WARN & INFO). Example: helmify -v")
 	flag.BoolVar(&result.VeryVerbose, "vv", false, "Enable very verbose output. Same as verbose but with DEBUG. Example: helmify -vv")
 	flag.BoolVar(&crd, "crd-dir", false, "Enable crd install into 'crds' directory.\nWarning: CRDs placed in 'crds' directory will not be templated by Helm.\nSee https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations\nExample: helmify -crd-dir")
-	flag.BoolVar(&imagePullSecrets.Enabled, "image-pull-secrets", false, "Enables imagePullSecrets in values.yaml to specify existing secrets.")
+	flag.BoolVar(&imagePullSecrets.Enabled, "image-pull-secrets", false, "Allows the user to use existing secrets as imagePullSecrets in values.yaml")
 
 	flag.Parse()
 	if h || help {

--- a/cmd/helmify/flags.go
+++ b/cmd/helmify/flags.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/arttor/helmify/pkg/config"
+	"github.com/arttor/helmify/pkg/processor/imagePullSecrets"
 )
 
 const helpText = `Helmify parses kubernetes resources from std.in and converts it to a Helm chart.
@@ -36,6 +37,8 @@ func ReadFlags() config.Config {
 	flag.BoolVar(&result.Verbose, "v", false, "Enable verbose output (print WARN & INFO). Example: helmify -v")
 	flag.BoolVar(&result.VeryVerbose, "vv", false, "Enable very verbose output. Same as verbose but with DEBUG. Example: helmify -vv")
 	flag.BoolVar(&crd, "crd-dir", false, "Enable crd install into 'crds' directory.\nWarning: CRDs placed in 'crds' directory will not be templated by Helm.\nSee https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations\nExample: helmify -crd-dir")
+	flag.BoolVar(&imagePullSecrets.Enabled, "image-pull-secrets", false, "Enables imagePullSecrets in values.yaml to specify existing secrets.")
+
 	flag.Parse()
 	if h || help {
 		fmt.Print(helpText)

--- a/examples/app/templates/daemonset.yaml
+++ b/examples/app/templates/daemonset.yaml
@@ -32,6 +32,7 @@ spec:
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true
+      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       terminationGracePeriodSeconds: 30
       tolerations:
       - effect: NoSchedule

--- a/examples/app/templates/deployment.yaml
+++ b/examples/app/templates/deployment.yaml
@@ -81,6 +81,7 @@ spec:
         - containerPort: 8443
           name: https
         resources: {}
+      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       securityContext:
         runAsNonRoot: true
       terminationGracePeriodSeconds: 10

--- a/examples/app/values.yaml
+++ b/examples/app/values.yaml
@@ -9,6 +9,7 @@ fluentdElasticsearch:
       requests:
         cpu: 100m
         memory: 200Mi
+imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
 myConfig:
   dummyconfigmapkey: dummyconfigmapvalue

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	VeryVerbose bool
 	// crd-dir set true to enable crd folder.
 	Crd bool
+	// ImagePullSecrets flag
+	ImagePullSecrets bool
 }
 
 func (c *Config) Validate() error {

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arttor/helmify/pkg/cluster"
 	"github.com/arttor/helmify/pkg/helmify"
+	"github.com/arttor/helmify/pkg/processor/imagePullSecrets"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -23,11 +24,13 @@ type output struct{}
 
 // Create a helm chart in the current directory:
 // chartName/
-//    ├── .helmignore   	# Contains patterns to ignore when packaging Helm charts.
-//    ├── Chart.yaml    	# Information about your chart
-//    ├── values.yaml   	# The default values for your templates
-//    └── templates/    	# The template files
-//        └── _helpers.tp   # Helm default template partials
+//
+//	├── .helmignore   	# Contains patterns to ignore when packaging Helm charts.
+//	├── Chart.yaml    	# Information about your chart
+//	├── values.yaml   	# The default values for your templates
+//	└── templates/    	# The template files
+//	    └── _helpers.tp   # Helm default template partials
+//
 // Overwrites existing values.yaml and templates in templates dir on every run.
 func (o output) Create(chartDir, chartName string, crd bool, templates []helmify.Template) error {
 	err := initChartDir(chartDir, chartName, crd)
@@ -104,6 +107,9 @@ func overwriteValuesFile(chartDir string, values helmify.Values) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to write marshal values.yaml")
 	}
+
+	res = append(res, []byte(imagePullSecrets.ValuesHelp)...)
+
 	file := filepath.Join(chartDir, "values.yaml")
 	err = ioutil.WriteFile(file, res, 0600)
 	if err != nil {

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/arttor/helmify/pkg/cluster"
 	"github.com/arttor/helmify/pkg/helmify"
-	"github.com/arttor/helmify/pkg/processor/imagePullSecrets"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -107,8 +106,6 @@ func overwriteValuesFile(chartDir string, values helmify.Values) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to write marshal values.yaml")
 	}
-
-	res = append(res, []byte(imagePullSecrets.ValuesHelp)...)
 
 	file := filepath.Join(chartDir, "values.yaml")
 	err = ioutil.WriteFile(file, res, 0600)

--- a/pkg/processor/daemonset/daemonset.go
+++ b/pkg/processor/daemonset/daemonset.go
@@ -149,7 +149,9 @@ func (d daemonset) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstru
 		return true, nil, err
 	}
 
-	imagePullSecrets.ProcessSpecMap(specMap, &values)
+	if appMeta.Config().ImagePullSecrets {
+		imagePullSecrets.ProcessSpecMap(specMap, &values)
+	}
 
 	spec, err := yamlformat.Marshal(specMap, 6)
 	if err != nil {

--- a/pkg/processor/daemonset/daemonset.go
+++ b/pkg/processor/daemonset/daemonset.go
@@ -149,7 +149,7 @@ func (d daemonset) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstru
 		return true, nil, err
 	}
 
-	imagePullSecrets.ProcessSpecMap(specMap)
+	imagePullSecrets.ProcessSpecMap(specMap, &values)
 
 	spec, err := yamlformat.Marshal(specMap, 6)
 	if err != nil {

--- a/pkg/processor/daemonset/daemonset.go
+++ b/pkg/processor/daemonset/daemonset.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arttor/helmify/pkg/cluster"
 	"github.com/arttor/helmify/pkg/processor"
+	"github.com/arttor/helmify/pkg/processor/imagePullSecrets"
 
 	"github.com/arttor/helmify/pkg/helmify"
 	yamlformat "github.com/arttor/helmify/pkg/yaml"
@@ -147,6 +148,9 @@ func (d daemonset) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstru
 	if err != nil {
 		return true, nil, err
 	}
+
+	imagePullSecrets.ProcessSpecMap(specMap)
+
 	spec, err := yamlformat.Marshal(specMap, 6)
 	if err != nil {
 		return true, nil, err

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arttor/helmify/pkg/cluster"
 	"github.com/arttor/helmify/pkg/processor"
+	"github.com/arttor/helmify/pkg/processor/imagePullSecrets"
 
 	"github.com/arttor/helmify/pkg/helmify"
 	yamlformat "github.com/arttor/helmify/pkg/yaml"
@@ -154,6 +155,9 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 	if err != nil {
 		return true, nil, err
 	}
+
+	imagePullSecrets.ProcessSpecMap(specMap)
+
 	spec, err := yamlformat.Marshal(specMap, 6)
 	if err != nil {
 		return true, nil, err

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -156,7 +156,7 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 		return true, nil, err
 	}
 
-	imagePullSecrets.ProcessSpecMap(specMap)
+	imagePullSecrets.ProcessSpecMap(specMap, &values)
 
 	spec, err := yamlformat.Marshal(specMap, 6)
 	if err != nil {

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -156,7 +156,9 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 		return true, nil, err
 	}
 
-	imagePullSecrets.ProcessSpecMap(specMap, &values)
+	if appMeta.Config().ImagePullSecrets {
+		imagePullSecrets.ProcessSpecMap(specMap, &values)
+	}
 
 	spec, err := yamlformat.Marshal(specMap, 6)
 	if err != nil {

--- a/pkg/processor/imagePullSecrets/imagePullSecrets.go
+++ b/pkg/processor/imagePullSecrets/imagePullSecrets.go
@@ -4,9 +4,16 @@ import "github.com/arttor/helmify/pkg/helmify"
 
 const helmExpression = "{{ .Values.imagePullSecrets | default list | toJson }}"
 
+// Enabled is set by flags to enable the feature
+var Enabled bool
+
 // ProcessSpecMap adds 'imagePullSecrets' to the podSpec in specMap, if it doesn't
 // already has one defined.
 func ProcessSpecMap(specMap map[string]interface{}, values *helmify.Values) {
+
+	if !Enabled {
+		return
+	}
 
 	if _, defined := specMap["imagePullSecrets"]; !defined {
 		specMap["imagePullSecrets"] = helmExpression

--- a/pkg/processor/imagePullSecrets/imagePullSecrets.go
+++ b/pkg/processor/imagePullSecrets/imagePullSecrets.go
@@ -1,0 +1,19 @@
+package imagePullSecrets
+
+const helmExpression = "{{ .Values.imagePullSecrets | default list | toJson }}"
+
+const ValuesHelp = `
+## you can specify existing secrets to be useds as imagePullSecrets
+# imagePullSecrets:
+# - name: image-pull-secret
+`
+
+// ProcessSpecMap adds 'imagePullSecrets' to the podSpec in specMap, if it doesn't
+// already has one defined.
+func ProcessSpecMap(specMap map[string]interface{}) {
+
+	if _, defined := specMap["imagePullSecrets"]; !defined {
+		specMap["imagePullSecrets"] = helmExpression
+	}
+
+}

--- a/pkg/processor/imagePullSecrets/imagePullSecrets.go
+++ b/pkg/processor/imagePullSecrets/imagePullSecrets.go
@@ -1,19 +1,16 @@
 package imagePullSecrets
 
-const helmExpression = "{{ .Values.imagePullSecrets | default list | toJson }}"
+import "github.com/arttor/helmify/pkg/helmify"
 
-const ValuesHelp = `
-## you can specify existing secrets to be useds as imagePullSecrets
-# imagePullSecrets:
-# - name: image-pull-secret
-`
+const helmExpression = "{{ .Values.imagePullSecrets | default list | toJson }}"
 
 // ProcessSpecMap adds 'imagePullSecrets' to the podSpec in specMap, if it doesn't
 // already has one defined.
-func ProcessSpecMap(specMap map[string]interface{}) {
+func ProcessSpecMap(specMap map[string]interface{}, values *helmify.Values) {
 
 	if _, defined := specMap["imagePullSecrets"]; !defined {
 		specMap["imagePullSecrets"] = helmExpression
+		(*values)["imagePullSecrets"] = []string{}
 	}
 
 }

--- a/pkg/processor/imagePullSecrets/imagePullSecrets.go
+++ b/pkg/processor/imagePullSecrets/imagePullSecrets.go
@@ -4,16 +4,9 @@ import "github.com/arttor/helmify/pkg/helmify"
 
 const helmExpression = "{{ .Values.imagePullSecrets | default list | toJson }}"
 
-// Enabled is set by flags to enable the feature
-var Enabled bool
-
 // ProcessSpecMap adds 'imagePullSecrets' to the podSpec in specMap, if it doesn't
 // already has one defined.
 func ProcessSpecMap(specMap map[string]interface{}, values *helmify.Values) {
-
-	if !Enabled {
-		return
-	}
 
 	if _, defined := specMap["imagePullSecrets"]; !defined {
 		specMap["imagePullSecrets"] = helmExpression

--- a/pkg/processor/imagePullSecrets/imagePullSecrets_test.go
+++ b/pkg/processor/imagePullSecrets/imagePullSecrets_test.go
@@ -3,6 +3,7 @@ package imagePullSecrets
 import (
 	"testing"
 
+	"github.com/arttor/helmify/pkg/helmify"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,20 +18,23 @@ func Test_imagePullSecrets_RespectExistingSpec(t *testing.T) {
 		{Name: "ips"},
 	}
 
-	ProcessSpecMap(spec)
+	values := &helmify.Values{}
+	ProcessSpecMap(spec, values)
 
 	assert.Equal(t, "ips", spec["imagePullSecrets"].([]ipsReference)[0].Name)
+	assert.Equal(t, 0, len(*values))
 
 }
 
 func Test_imagePullSecrets_ProvideDefault(t *testing.T) {
 	spec := make(map[string]interface{})
 
-	ProcessSpecMap(spec)
+	values := &helmify.Values{}
+	ProcessSpecMap(spec, values)
 
 	ips, found := spec["imagePullSecrets"]
 	assert.True(t, found)
 
 	assert.Equal(t, ips, helmExpression)
-
+	assert.Equal(t, 1, len(*values))
 }

--- a/pkg/processor/imagePullSecrets/imagePullSecrets_test.go
+++ b/pkg/processor/imagePullSecrets/imagePullSecrets_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func Test_imagePullSecrets_RespectExistingSpec(t *testing.T) {
-	Enabled = true
 	spec := make(map[string]interface{})
 
 	type ipsReference struct {
@@ -28,7 +27,6 @@ func Test_imagePullSecrets_RespectExistingSpec(t *testing.T) {
 }
 
 func Test_imagePullSecrets_ProvideDefault(t *testing.T) {
-	Enabled = true
 	spec := make(map[string]interface{})
 
 	values := &helmify.Values{}
@@ -39,17 +37,4 @@ func Test_imagePullSecrets_ProvideDefault(t *testing.T) {
 
 	assert.Equal(t, ips, helmExpression)
 	assert.Equal(t, 1, len(*values))
-}
-
-func Test_imagePullSecrets_DoNothingIfNotEnabled(t *testing.T) {
-	Enabled = false
-	spec := make(map[string]interface{})
-
-	values := &helmify.Values{}
-	ProcessSpecMap(spec, values)
-
-	_, found := spec["imagePullSecrets"]
-	assert.False(t, found)
-
-	assert.Equal(t, 0, len(*values))
 }

--- a/pkg/processor/imagePullSecrets/imagePullSecrets_test.go
+++ b/pkg/processor/imagePullSecrets/imagePullSecrets_test.go
@@ -1,0 +1,36 @@
+package imagePullSecrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_imagePullSecrets_RespectExistingSpec(t *testing.T) {
+	spec := make(map[string]interface{})
+
+	type ipsReference struct {
+		Name string
+	}
+
+	spec["imagePullSecrets"] = []ipsReference{
+		{Name: "ips"},
+	}
+
+	ProcessSpecMap(spec)
+
+	assert.Equal(t, "ips", spec["imagePullSecrets"].([]ipsReference)[0].Name)
+
+}
+
+func Test_imagePullSecrets_ProvideDefault(t *testing.T) {
+	spec := make(map[string]interface{})
+
+	ProcessSpecMap(spec)
+
+	ips, found := spec["imagePullSecrets"]
+	assert.True(t, found)
+
+	assert.Equal(t, ips, helmExpression)
+
+}

--- a/pkg/processor/imagePullSecrets/imagePullSecrets_test.go
+++ b/pkg/processor/imagePullSecrets/imagePullSecrets_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func Test_imagePullSecrets_RespectExistingSpec(t *testing.T) {
+	Enabled = true
 	spec := make(map[string]interface{})
 
 	type ipsReference struct {
@@ -27,6 +28,7 @@ func Test_imagePullSecrets_RespectExistingSpec(t *testing.T) {
 }
 
 func Test_imagePullSecrets_ProvideDefault(t *testing.T) {
+	Enabled = true
 	spec := make(map[string]interface{})
 
 	values := &helmify.Values{}
@@ -37,4 +39,17 @@ func Test_imagePullSecrets_ProvideDefault(t *testing.T) {
 
 	assert.Equal(t, ips, helmExpression)
 	assert.Equal(t, 1, len(*values))
+}
+
+func Test_imagePullSecrets_DoNothingIfNotEnabled(t *testing.T) {
+	Enabled = false
+	spec := make(map[string]interface{})
+
+	values := &helmify.Values{}
+	ProcessSpecMap(spec, values)
+
+	_, found := spec["imagePullSecrets"]
+	assert.False(t, found)
+
+	assert.Equal(t, 0, len(*values))
 }


### PR DESCRIPTION
This is the very minimal implementation. Some notes:

* I can't use a default value for the `imagePullSecrets` in `values.yaml`, as this should only be specified by the user if necessary. To let the user know about the feature, I render a comment in `values.yaml` with an example how to use it.
* I use `toJson` in the helm expression to get started somewhere
* There could be some refactoring done generally to handle `PodSpec` uniformly in one place. Currently there is quite a few duplicate code in `daemonset.go` and `deployment.go`. For this PR I just kept it like it is, and implemented in handling in an own package
* I tested the generate e2e app chart, and it looked good at the first glace.

Please let me know what you think about it.

