### PR TITLE
feat: added support for aggregationRule in clusterRole

### DIFF
--- a/pkg/processor/rbac/role_test.go
+++ b/pkg/processor/rbac/role_test.go
@@ -14,6 +14,11 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: my-operator-manager-role
+aggregationRule:
+  clusterRoleSelectors:
+  - matchExpressions:
+    - key: my.operator.dev/release
+      operator: Exists
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
Add support for adding `aggregationRule` set in `clusterRole` kind, optionally.
This also validates the kind `Role` if someone has wrongfully placed this object in the manifest