### PR TITLE
fix: env vars with default values in values.yaml

### DIFF
--- a/examples/operator/templates/deployment.yaml
+++ b/examples/operator/templates/deployment.yaml
@@ -53,9 +53,9 @@ spec:
               key: VAR1
               name: {{ include "operator.fullname" . }}-secret-vars
         - name: VAR2
-          value: {{ .Values.controllerManager.manager.var2 }}
+          value: {{ .Values.controllerManager.manager.env.var2 }}
         - name: VAR3_MY_ENV
-          value: {{ .Values.controllerManager.manager.var3MyEnv }}
+          value: {{ .Values.controllerManager.manager.env.var3MyEnv }}
         - name: VAR4
           valueFrom:
             configMapKeyRef:

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -47,7 +47,7 @@ const selectorTempl = `%[1]s
 {{- include "%[2]s.selectorLabels" . | nindent 6 }}
 %[3]s`
 
-const envValue = "{{ .Values.%[1]s.%[2]s.%[3]s }}"
+const envValue = "{{ .Values.%[1]s.%[2]s.%[3]s.%[4]s }}"
 
 // New creates processor for k8s Deployment resource.
 func New() helmify.Processor {
@@ -299,7 +299,7 @@ func processEnv(name string, appMeta helmify.AppMetadata, c corev1.Container, va
 		if err != nil {
 			return c, errors.Wrap(err, "unable to set deployment value field")
 		}
-		c.Env[i].Value = fmt.Sprintf(envValue, name, containerName, strcase.ToLowerCamel(strings.ToLower(c.Env[i].Name)))
+		c.Env[i].Value = fmt.Sprintf(envValue, name, containerName, "env", strcase.ToLowerCamel(strings.ToLower(c.Env[i].Name)))
 	}
 	return c, nil
 }


### PR DESCRIPTION
we were generating values.yaml with

```
controllerManager:
  manager:
    env:
      key: value
```

but the deployment manifest had:

```
env:
  - name: key
    value: value: {{ .Values.controllerManager.manager.key }}
```

(it was missing the "env" level...)

so is now fixed by this change