### PR TITLE
always use quotes for env values

### DIFF
--- a/pkg/processor/daemonset/daemonset.go
+++ b/pkg/processor/daemonset/daemonset.go
@@ -238,7 +238,7 @@ func processPodContainer(name string, appMeta helmify.AppMetadata, c corev1.Cont
 	}
 	c.Env = append(c.Env, corev1.EnvVar{
 		Name:  cluster.DomainEnv,
-		Value: fmt.Sprintf("{{ .Values.%s }}", cluster.DomainKey),
+		Value: fmt.Sprintf("{{ quote .Values.%s }}", cluster.DomainKey),
 	})
 	for k, v := range c.Resources.Requests {
 		err = unstructured.SetNestedField(*values, v.ToUnstructured(), name, containerName, "resources", "requests", k.String())

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -48,7 +48,7 @@ const selectorTempl = `%[1]s
 %[3]s`
 
 const imagePullPolicyTemplate = "{{ .Values.%[1]s.%[2]s.imagePullPolicy }}"
-const envValue = "{{ .Values.%[1]s.%[2]s.%[3]s.%[4]s }}"
+const envValue = "{{ quote .Values.%[1]s.%[2]s.%[3]s.%[4]s }}"
 
 // New creates processor for k8s Deployment resource.
 func New() helmify.Processor {
@@ -276,7 +276,7 @@ func processPodContainer(name string, appMeta helmify.AppMetadata, c corev1.Cont
 	}
 	c.Env = append(c.Env, corev1.EnvVar{
 		Name:  cluster.DomainEnv,
-		Value: fmt.Sprintf("{{ .Values.%s }}", cluster.DomainKey),
+		Value: fmt.Sprintf("{{ quote .Values.%s }}", cluster.DomainKey),
 	})
 	for k, v := range c.Resources.Requests {
 		err = unstructured.SetNestedField(*values, v.ToUnstructured(), name, containerName, "resources", "requests", k.String())


### PR DESCRIPTION
With the new structure for specifying env vars in the template we are experiencing issues. We have a deployment with env var that is either a bool or a number. So normally we specify it as:
```yaml
env:
- name: TEST
   value: "1"
```

When that passes through `helmify` we get a template that looks like this:
```yaml
env:
        - name: TEST
          value: {{ .Values.controllerManager.manager.env.test
            }}
```
When the template is parsed, the value "1" gets replace but then the resulting yaml is:
```yaml
env:
- name: TEST
   value: 1
```

This is invalid and is rejected by Kubernetes since the env value must always be a string. The same issue would occur if the env value is a boolean.

This PR is an attempt to fix the problem. I already tested that this approach fixes our issue but feel free to adjust it if needed