### PR TITLE
further indent container securityContext values

### DIFF
--- a/pkg/processor/security-context/container_security_context.go
+++ b/pkg/processor/security-context/container_security_context.go
@@ -11,7 +11,7 @@ import (
 const (
 	sc           = "securityContext"
 	cscValueName = "containerSecurityContext"
-	helmTemplate = "{{- toYaml .Values.%[1]s.%[2]s.containerSecurityContext | nindent 8 }}"
+	helmTemplate = "{{- toYaml .Values.%[1]s.%[2]s.containerSecurityContext | nindent 10 }}"
 )
 
 // ProcessContainerSecurityContext adds 'securityContext' to the podSpec in specMap, if it doesn't have one already defined.


### PR DESCRIPTION
The Deployment template generated for the section covering the container 'securityContext' (not the pod 'securityContext') looks like:

```
       resources: {{- toYaml .Values.controllerManager.manager.resources
| nindent 10
          }}
        securityContext: {{- toYaml
.Values.controllerManager.manager.containerSecurityContext
          | nindent 8 }}
      securityContext:
        runAsNonRoot: true
```

As can be seen with the container's 'resources' right above, the appropriate indentation for container values should be '10'.

Otherwise, helm ends up outputting invalid Pod yaml:

```
$ helm template mondoo-operator charts/mondoo-operator -n mondoo-operator --create-namespace --wait | grep -A 6 securityContext
        securityContext:
        allowPrivilegeEscalation: false
        capabilities:
          drop:
          - ALL
        privileged: false
        readOnlyRootFilesystem: true
      securityContext:
        runAsNonRoot: true
      serviceAccountName: mondoo-operator-controller-manager
      terminationGracePeriodSeconds: 10
```

If we were indeed templating data in the pod 'securityContext' (right below), then '8' would have been appropriate.