### PR TITLE
Add an option cert-manager-as-subchart to install the cert-manager as a subchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Usage:
 | -version | Print helmify version.                                                                                                                                                                                      | `helmify -version`|
 | -crd-dir | Place crds in their own folder per Helm 3 [docs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you). Caveat: CRDs templating is not supported by Helm. | `helmify -crd-dir`|
 | -image-pull-secrets| Allows the user to use existing secrets as imagePullSecrets  | `helmify -image-pull-secrets`|
-
+| -cert-manager-as-subchart | Allows the user to install cert-manager as a subchart  | `helmify -cert-manager-as-subchart`|
 ## Status
 Supported k8s resources:
 - Deployment, DaemonSet, StatefulSet

--- a/cmd/helmify/flags.go
+++ b/cmd/helmify/flags.go
@@ -38,6 +38,7 @@ func ReadFlags() config.Config {
 	flag.BoolVar(&crd, "crd-dir", false, "Enable crd install into 'crds' directory.\nWarning: CRDs placed in 'crds' directory will not be templated by Helm.\nSee https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations\nExample: helmify -crd-dir")
 	flag.BoolVar(&result.ImagePullSecrets, "image-pull-secrets", false, "Allows the user to use existing secrets as imagePullSecrets in values.yaml")
 	flag.BoolVar(&result.GenerateDefaults, "generate-defaults", false, "Allows the user to add empty placeholders for tipical customization options in values.yaml. Currently covers: topology constraints, node selectors, tolerances")
+	flag.BoolVar(&result.CertManagerAsSubchart, "cert-manager-as-subchart", false, "Allows the user to add cert-manager as a subchart")
 
 	flag.Parse()
 	if h || help {

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -67,7 +67,7 @@ func (c *appContext) CreateHelm(stop <-chan struct{}) error {
 		default:
 		}
 	}
-	return c.output.Create(c.config.ChartDir, c.config.ChartName, c.config.Crd, templates)
+	return c.output.Create(c.config.ChartDir, c.config.ChartName, c.config.Crd, c.config.CertManagerAsSubchart, templates)
 }
 
 func (c *appContext) process(obj *unstructured.Unstructured) (helmify.Template, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	// GenerateDefaults enables the generation of empty values placeholders for common customization options of helm chart
 	// current generated values: tolerances, node selectors, topology constraints
 	GenerateDefaults bool
+	// CertManagerAsSubchart enables the generation of a subchart for cert-manager
+	CertManagerAsSubchart bool
 }
 
 func (c *Config) Validate() error {

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -31,8 +31,8 @@ type output struct{}
 //	    └── _helpers.tp   # Helm default template partials
 //
 // Overwrites existing values.yaml and templates in templates dir on every run.
-func (o output) Create(chartDir, chartName string, crd bool, templates []helmify.Template) error {
-	err := initChartDir(chartDir, chartName, crd)
+func (o output) Create(chartDir, chartName string, crd bool, certManagerAsSubchart bool, templates []helmify.Template) error {
+	err := initChartDir(chartDir, chartName, crd, certManagerAsSubchart)
 	if err != nil {
 		return err
 	}
@@ -108,6 +108,7 @@ func overwriteValuesFile(chartDir string, values helmify.Values) error {
 	}
 
 	file := filepath.Join(chartDir, "values.yaml")
+	res = append(res, []byte("cert-manager:\n  enabled: false\n  installCRDs: true")...)
 	err = ioutil.WriteFile(file, res, 0600)
 	if err != nil {
 		return errors.Wrap(err, "unable to write values.yaml")

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -56,7 +56,7 @@ func (o output) Create(chartDir, chartName string, crd bool, certManagerAsSubcha
 			return err
 		}
 	}
-	err = overwriteValuesFile(cDir, values)
+	err = overwriteValuesFile(cDir, values, certManagerAsSubchart)
 	if err != nil {
 		return err
 	}
@@ -101,14 +101,17 @@ func overwriteTemplateFile(filename, chartDir string, crd bool, templates []helm
 	return nil
 }
 
-func overwriteValuesFile(chartDir string, values helmify.Values) error {
+func overwriteValuesFile(chartDir string, values helmify.Values, certManagerAsSubchart bool) error {
+	if certManagerAsSubchart {
+		values.Add(true, "cert-manager", "installCRDs")
+		values.Add(true, "cert-manager", "enabled")
+	}
 	res, err := yaml.Marshal(values)
 	if err != nil {
 		return errors.Wrap(err, "unable to write marshal values.yaml")
 	}
 
 	file := filepath.Join(chartDir, "values.yaml")
-	res = append(res, []byte("cert-manager:\n  enabled: false\n  installCRDs: true")...)
 	err = ioutil.WriteFile(file, res, 0600)
 	if err != nil {
 		return errors.Wrap(err, "unable to write values.yaml")

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -103,8 +103,15 @@ func overwriteTemplateFile(filename, chartDir string, crd bool, templates []helm
 
 func overwriteValuesFile(chartDir string, values helmify.Values, certManagerAsSubchart bool) error {
 	if certManagerAsSubchart {
-		values.Add(true, "cert-manager", "installCRDs")
-		values.Add(true, "cert-manager", "enabled")
+		_, err := values.Add(true, "cert-manager", "installCRDs")
+		if err != nil {
+			return errors.Wrap(err, "unable to add cert-manager.installCRDs")
+		}
+
+		_, err = values.Add(true, "cert-manager", "enabled")
+		if err != nil {
+			return errors.Wrap(err, "unable to add cert-manager.enabled")
+		}
 	}
 	res, err := yaml.Marshal(values)
 	if err != nil {

--- a/pkg/helm/init.go
+++ b/pkg/helm/init.go
@@ -183,9 +183,14 @@ func createCommonFiles(chartDir, chartName string, crd bool, certManagerAsSubcha
 
 func chartYAML(appName string, certManagerAsSubchart bool) []byte {
 	chartFile := defaultChartfile
+	annotatins := `
+dependencies:
+  - name: cert-manager
+    version: 1.9.1
+    repository: https://charts.jetstack.io
+    condition: certManager.enabled`
 	if certManagerAsSubchart {
-		chartFile += "\ndependencies:\n  - name: cert-manager\n    version: 1.9.1\n" +
-			"    repository: https://charts.jetstack.io\n    condition: cert-manager.enabled"
+		chartFile += annotatins
 	}
 	return []byte(fmt.Sprintf(chartFile, appName))
 }

--- a/pkg/helm/init.go
+++ b/pkg/helm/init.go
@@ -186,7 +186,6 @@ func chartYAML(appName string, certManagerAsSubchart bool) []byte {
 	annotatins := `
 dependencies:
   - name: cert-manager
-    version: 1.9.1
     repository: https://charts.jetstack.io
     condition: certManager.enabled`
 	if certManagerAsSubchart {

--- a/pkg/helmify/model.go
+++ b/pkg/helmify/model.go
@@ -1,8 +1,9 @@
 package helmify
 
 import (
-	"github.com/arttor/helmify/pkg/config"
 	"io"
+
+	"github.com/arttor/helmify/pkg/config"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -27,7 +28,7 @@ type Template interface {
 
 // Output - converts Template into helm chart on disk.
 type Output interface {
-	Create(chartName, chartDir string, Crd bool, templates []Template) error
+	Create(chartName, chartDir string, Crd bool, certManagerAsSubchart bool, templates []Template) error
 }
 
 // AppMetadata handle common information about K8s objects in the chart.


### PR DESCRIPTION
The pr is to add an option `cert-manager-as-subchart` to install the cert-manager as a subchart, it's useful for operator as the cert-manager must be installed before deploying the operator.