### PR TITLE
fix: indent issue in the Makefile demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Submit issue if some features missing for your use-case.
         test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
         
     helm: manifests kustomize helmify
-	$(KUSTOMIZE) build config/default | $(HELMIFY)
+	    $(KUSTOMIZE) build config/default | $(HELMIFY)
     ```
 3. Run `make helm` in project root. It will generate helm chart with name 'chart' in 'chart' directory.
 


### PR DESCRIPTION
# Motivation

There is an indent issue in the demo code, it will cause the `make helm` command fail when user use it directly.
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/12933837/228772855-af1350c0-3b9f-4b38-923f-f7b283fe8b6b.png">
