### PR TITLE
fix: indent issue in the Makefile demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Submit issue if some features missing for your use-case.
     .PHONY: helmify
     helmify: $(HELMIFY) ## Download helmify locally if necessary.
     $(HELMIFY): $(LOCALBIN)
-        test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
+    	test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
         
     helm: manifests kustomize helmify
-	$(KUSTOMIZE) build config/default | $(HELMIFY)
+    	$(KUSTOMIZE) build config/default | $(HELMIFY)
     ```
 3. Run `make helm` in project root. It will generate helm chart with name 'chart' in 'chart' directory.
 


### PR DESCRIPTION
# Motivation 
There is an indent issue in the demo code, it will cause the make helm command fail when user use it directly.
<img width="949" alt="image" src="https://user-images.githubusercontent.com/12933837/228778356-7a3ac8de-9bc2-46dc-a64b-6c8596547974.png">
