### PR TITLE
Fix cert manager by using an alias

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -103,12 +103,12 @@ func overwriteTemplateFile(filename, chartDir string, crd bool, templates []helm
 
 func overwriteValuesFile(chartDir string, values helmify.Values, certManagerAsSubchart bool) error {
 	if certManagerAsSubchart {
-		_, err := values.Add(true, "cert-manager", "installCRDs")
+		_, err := values.Add(true, "certmanager", "installCRDs")
 		if err != nil {
 			return errors.Wrap(err, "unable to add cert-manager.installCRDs")
 		}
 
-		_, err = values.Add(true, "cert-manager", "enabled")
+		_, err = values.Add(true, "certmanager", "enabled")
 		if err != nil {
 			return errors.Wrap(err, "unable to add cert-manager.enabled")
 		}

--- a/pkg/helm/init.go
+++ b/pkg/helm/init.go
@@ -124,6 +124,14 @@ version: 0.1.0
 appVersion: "0.1.0"
 `
 
+const certManagerDependencies = `
+dependencies:
+  - name: cert-manager
+    repository: https://charts.jetstack.io
+    condition: certmanager.enabled
+	alias: certmanager
+`
+
 var chartName = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
 
 const maxChartNameLength = 250
@@ -183,13 +191,8 @@ func createCommonFiles(chartDir, chartName string, crd bool, certManagerAsSubcha
 
 func chartYAML(appName string, certManagerAsSubchart bool) []byte {
 	chartFile := defaultChartfile
-	annotatins := `
-dependencies:
-  - name: cert-manager
-    repository: https://charts.jetstack.io
-    condition: certManager.enabled`
 	if certManagerAsSubchart {
-		chartFile += annotatins
+		chartFile += certManagerDependencies
 	}
 	return []byte(fmt.Sprintf(chartFile, appName))
 }


### PR DESCRIPTION
## Description

The issue I was having is that the key `certManager` in `values.yaml` is not passed to the dependencies. That key should have been `cert-manager` for `installCRDs` to be passed to the dependency. The current code tries to do that, but it ends up being converted to camelCase, so while it correctly enables the dependency, nothing is passed. Since we cannot use camelCase for a dependency alias, I chose to use flatcase.