### PR TITLE
Add an option for enable/disable webhook for a standard operator generated by kubebuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Usage:
 | -cert-manager-version     | Allows the user to specify cert-manager subchart version. Only useful with cert-manager-as-subchart. (default "v1.12.2")                                                                                    | `helmify -cert-manager-version=v1.12.2`    |
 | -cert-manager-install-crd     | Allows the user to install cert-manager CRD as part of the cert-manager subchart.(default "true")                                                                                                           | `helmify -cert-manager-install-crd` |
 | -preserve-ns              | Allows users to use the object's original namespace instead of adding all the resources to a common namespace. (default "false")                                                                            | `helmify -preserve-ns`              |
+| -add-webhook-option | Adds an option to enable/disable webhook installation  | `helmify -add-webhook-option`|
 ## Status
 Supported k8s resources:
 - Deployment, DaemonSet, StatefulSet

--- a/cmd/helmify/flags.go
+++ b/cmd/helmify/flags.go
@@ -70,6 +70,8 @@ func ReadFlags() config.Config {
 	flag.BoolVar(&result.OriginalName, "original-name", false, "Use the object's original name instead of adding the chart's release name as the common prefix.")
 	flag.Var(&files, "f", "File or directory containing k8s manifests")
 	flag.BoolVar(&preservens, "preserve-ns", false, "Use the object's original namespace instead of adding all the resources to a common namespace")
+	flag.BoolVar(&result.AddWebhookOption, "add-webhook-option", false, "Allows the user to add webhook option in values.yaml")
+
 	flag.Parse()
 	if h || help {
 		fmt.Print(helpText)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -40,6 +41,8 @@ type Config struct {
 	OriginalName bool
 	// PreserveNs retains the namespaces on the Kubernetes manifests
 	PreserveNs bool
+	// AddWebhookOption enables the generation of a webhook option in values.yamlß
+	AddWebhookOption bool
 }
 
 func (c *Config) Validate() error {

--- a/pkg/processor/service/service.go
+++ b/pkg/processor/service/service.go
@@ -94,8 +94,12 @@ func (r svc) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 		}
 		ports[i] = pMap
 	}
+
 	_ = unstructured.SetNestedSlice(values, ports, shortNameCamel, "ports")
 	res := meta + fmt.Sprintf(svcTempSpec, shortNameCamel, selector, appMeta.ChartName())
+	if shortNameCamel == "webhookService" && appMeta.Config().AddWebhookOption {
+		res = fmt.Sprintf("{{- if .Values.webhook.enabled }}\n%s\n{{- end }}", res)
+	}
 	return true, &result{
 		name:   shortName,
 		data:   res,

--- a/pkg/processor/webhook/validating.go
+++ b/pkg/processor/webhook/validating.go
@@ -65,7 +65,15 @@ func (w vwh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 	}
 	certName = strings.TrimPrefix(certName, appMeta.Namespace()+"/")
 	certName = appMeta.TrimName(certName)
-	res := fmt.Sprintf(vwhTempl, appMeta.ChartName(), name, certName, string(webhooks))
+	tmpl := vwhTempl
+	values := helmify.Values{}
+	if appMeta.Config().AddWebhookOption {
+		// Add webhook.enabled value to values.yaml
+		_, _ = values.Add(true, "webhook", "enabled")
+
+		tmpl = fmt.Sprintf("%s\n%s\n%s", WebhookHeader, mwhTempl, WebhookFooter)
+	}
+	res := fmt.Sprintf(tmpl, appMeta.ChartName(), name, certName, string(webhooks))
 	return true, &vwhResult{
 		name: name,
 		data: []byte(res),
@@ -73,8 +81,9 @@ func (w vwh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 }
 
 type vwhResult struct {
-	name string
-	data []byte
+	name   string
+	data   []byte
+	values helmify.Values
 }
 
 func (r *vwhResult) Filename() string {
@@ -82,7 +91,7 @@ func (r *vwhResult) Filename() string {
 }
 
 func (r *vwhResult) Values() helmify.Values {
-	return helmify.Values{}
+	return r.values
 }
 
 func (r *vwhResult) Write(writer io.Writer) error {


### PR DESCRIPTION
As titled. Fix #57.