### PR TITLE
[serviceaccount] Annotations as Values Support

### DIFF
--- a/examples/operator/templates/deployment.yaml
+++ b/examples/operator/templates/deployment.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "operator.fullname" . }}-controller-manager
-  labels:
-  {{- include "operator.labels" . | nindent 4 }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/examples/operator/templates/serviceaccount.yaml
+++ b/examples/operator/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "operator.fullname" . }}-controller-manager
+  labels:
+  {{- include "operator.labels" . | nindent 4 }}
+  annotations:
+    k8s.acme.org/some-meta-data: ACME Inc.
+  {{ toYaml .Values.controllerManager.annotations | nindent 4 }}

--- a/examples/operator/values.yaml
+++ b/examples/operator/values.yaml
@@ -35,6 +35,8 @@ controllerManager:
     region: east
     type: user-node
   replicas: 1
+  serviceaccount:
+    annotations: {}
 kubernetesClusterDomain: cluster.local
 managerConfig:
   controllerManagerConfigYaml: |-

--- a/pkg/processor/rbac/serviceaccount.go
+++ b/pkg/processor/rbac/serviceaccount.go
@@ -47,7 +47,7 @@ metadata:
   labels:
 %[5]s
   {{- include "%[4]s.labels" . | nindent 4 }}
-  annotations
+  annotations:
 %[6]s
   {{ toYaml .Values.%[7]s.annotations | nindent 4 }}`
 

--- a/pkg/processor/rbac/serviceaccount.go
+++ b/pkg/processor/rbac/serviceaccount.go
@@ -47,6 +47,7 @@ metadata:
   labels:
 %[5]s
   {{- include "%[4]s.labels" . | nindent 4 }}
+  annotations
 %[6]s
   {{ toYaml .Values.%[7]s.annotations | nindent 4 }}`
 
@@ -55,7 +56,7 @@ func (sa serviceAccount) processServiceAccountMeta(appMeta helmify.AppMetadata, 
 	var labels, annotations string
 	values := helmify.Values{}
 	name := strcase.ToLowerCamel(appMeta.TrimName(obj.GetName()))
-	err = unstructured.SetNestedField(values, map[string]interface{}{}, name, "annotations")
+	err = unstructured.SetNestedField(values, map[string]interface{}{}, name, "serviceaccount", "annotations")
 	if err != nil {
 		return "", nil, err
 	}
@@ -77,7 +78,7 @@ func (sa serviceAccount) processServiceAccountMeta(appMeta helmify.AppMetadata, 
 		}
 	}
 	if len(obj.GetAnnotations()) != 0 {
-		annotations, err = yamlformat.Marshal(map[string]interface{}{"annotations": obj.GetAnnotations()}, 2)
+		annotations, err = yamlformat.Marshal(obj.GetAnnotations(), 4)
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/processor/rbac/serviceaccount.go
+++ b/pkg/processor/rbac/serviceaccount.go
@@ -1,14 +1,11 @@
 package rbac
 
 import (
-	"fmt"
 	"github.com/arttor/helmify/pkg/helmify"
-	yamlformat "github.com/arttor/helmify/pkg/yaml"
-	"github.com/iancoleman/strcase"
+	"github.com/arttor/helmify/pkg/processor"
 	"io"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"strings"
 )
 
 var serviceAccountGVC = schema.GroupVersionKind{
@@ -29,7 +26,8 @@ func (sa serviceAccount) Process(appMeta helmify.AppMetadata, obj *unstructured.
 	if obj.GroupVersionKind() != serviceAccountGVC {
 		return false, nil, nil
 	}
-	meta, values, err := sa.processServiceAccountMeta(appMeta, obj)
+	values := helmify.Values{}
+	meta, err := processor.ProcessObjMeta(appMeta, obj, processor.WithAnnotations(values))
 	if err != nil {
 		return true, nil, err
 	}
@@ -38,57 +36,6 @@ func (sa serviceAccount) Process(appMeta helmify.AppMetadata, obj *unstructured.
 		data:   []byte(meta),
 		values: values,
 	}, nil
-}
-
-const metaTeml = `apiVersion: %[1]s
-kind: %[2]s
-metadata:
-  name: %[3]s
-  labels:
-%[5]s
-  {{- include "%[4]s.labels" . | nindent 4 }}
-  annotations:
-%[6]s
-  {{ toYaml .Values.%[7]s.annotations | nindent 4 }}`
-
-func (sa serviceAccount) processServiceAccountMeta(appMeta helmify.AppMetadata, obj *unstructured.Unstructured) (string, helmify.Values, error) {
-	var err error
-	var labels, annotations string
-	values := helmify.Values{}
-	name := strcase.ToLowerCamel(appMeta.TrimName(obj.GetName()))
-	err = unstructured.SetNestedField(values, map[string]interface{}{}, name, "serviceaccount", "annotations")
-	if err != nil {
-		return "", nil, err
-	}
-	if len(obj.GetLabels()) != 0 {
-		l := obj.GetLabels()
-		// provided by Helm
-		delete(l, "app.kubernetes.io/name")
-		delete(l, "app.kubernetes.io/instance")
-		delete(l, "app.kubernetes.io/version")
-		delete(l, "app.kubernetes.io/managed-by")
-		delete(l, "helm.sh/chart")
-
-		// Since we delete labels above, it is possible that at this point there are no more labels.
-		if len(l) > 0 {
-			labels, err = yamlformat.Marshal(l, 4)
-			if err != nil {
-				return "", nil, err
-			}
-		}
-	}
-	if len(obj.GetAnnotations()) != 0 {
-		annotations, err = yamlformat.Marshal(obj.GetAnnotations(), 4)
-		if err != nil {
-			return "", nil, err
-		}
-	}
-	templatedName := appMeta.TemplatedName(obj.GetName())
-	apiVersion, kind := obj.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
-	metaStr := fmt.Sprintf(metaTeml, apiVersion, kind, templatedName, appMeta.ChartName(), labels, annotations, name)
-	metaStr = strings.Trim(metaStr, " \n")
-	metaStr = strings.ReplaceAll(metaStr, "\n\n", "\n")
-	return metaStr, values, nil
 }
 
 type saResult struct {

--- a/pkg/processor/rbac/serviceaccount.go
+++ b/pkg/processor/rbac/serviceaccount.go
@@ -1,12 +1,14 @@
 package rbac
 
 import (
-	"io"
-
+	"fmt"
 	"github.com/arttor/helmify/pkg/helmify"
-	"github.com/arttor/helmify/pkg/processor"
+	yamlformat "github.com/arttor/helmify/pkg/yaml"
+	"github.com/iancoleman/strcase"
+	"io"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"strings"
 )
 
 var serviceAccountGVC = schema.GroupVersionKind{
@@ -27,25 +29,78 @@ func (sa serviceAccount) Process(appMeta helmify.AppMetadata, obj *unstructured.
 	if obj.GroupVersionKind() != serviceAccountGVC {
 		return false, nil, nil
 	}
-	meta, err := processor.ProcessObjMeta(appMeta, obj)
+	meta, values, err := sa.processServiceAccountMeta(appMeta, obj)
 	if err != nil {
 		return true, nil, err
 	}
+
 	return true, &saResult{
-		data: []byte(meta),
+		data:   []byte(meta),
+		values: values,
 	}, nil
 }
 
+const metaTeml = `apiVersion: %[1]s
+kind: %[2]s
+metadata:
+  name: %[3]s
+  labels:
+%[5]s
+  {{- include "%[4]s.labels" . | nindent 4 }}
+%[6]s
+  {{ toYaml .Values.%[7]s.annotations | nindent 4 }}`
+
+func (sa serviceAccount) processServiceAccountMeta(appMeta helmify.AppMetadata, obj *unstructured.Unstructured) (string, helmify.Values, error) {
+	var err error
+	var labels, annotations string
+	values := helmify.Values{}
+	name := strcase.ToLowerCamel(appMeta.TrimName(obj.GetName()))
+	err = unstructured.SetNestedField(values, map[string]interface{}{}, name, "annotations")
+	if err != nil {
+		return "", nil, err
+	}
+	if len(obj.GetLabels()) != 0 {
+		l := obj.GetLabels()
+		// provided by Helm
+		delete(l, "app.kubernetes.io/name")
+		delete(l, "app.kubernetes.io/instance")
+		delete(l, "app.kubernetes.io/version")
+		delete(l, "app.kubernetes.io/managed-by")
+		delete(l, "helm.sh/chart")
+
+		// Since we delete labels above, it is possible that at this point there are no more labels.
+		if len(l) > 0 {
+			labels, err = yamlformat.Marshal(l, 4)
+			if err != nil {
+				return "", nil, err
+			}
+		}
+	}
+	if len(obj.GetAnnotations()) != 0 {
+		annotations, err = yamlformat.Marshal(map[string]interface{}{"annotations": obj.GetAnnotations()}, 2)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+	templatedName := appMeta.TemplatedName(obj.GetName())
+	apiVersion, kind := obj.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+	metaStr := fmt.Sprintf(metaTeml, apiVersion, kind, templatedName, appMeta.ChartName(), labels, annotations, name)
+	metaStr = strings.Trim(metaStr, " \n")
+	metaStr = strings.ReplaceAll(metaStr, "\n\n", "\n")
+	return metaStr, values, nil
+}
+
 type saResult struct {
-	data []byte
+	data   []byte
+	values helmify.Values
 }
 
 func (r *saResult) Filename() string {
-	return "deployment.yaml"
+	return "serviceaccount.yaml"
 }
 
 func (r *saResult) Values() helmify.Values {
-	return helmify.Values{}
+	return r.values
 }
 
 func (r *saResult) Write(writer io.Writer) error {

--- a/test_data/k8s-operator-ci.yaml
+++ b/test_data/k8s-operator-ci.yaml
@@ -313,6 +313,8 @@ kind: ServiceAccount
 metadata:
   name: my-operator-controller-manager
   namespace: my-operator-system
+  annotations:
+    k8s.acme.org/some-meta-data: "ACME Inc."
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/test_data/k8s-operator-kustomize.output
+++ b/test_data/k8s-operator-kustomize.output
@@ -323,6 +323,8 @@ kind: ServiceAccount
 metadata:
   name: my-operator-controller-manager
   namespace: my-operator-system
+  annotations:
+    k8s.acme.org/some-meta-data: "ACME Inc."
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
I'd like to be able to include annotations on my operator's ServiceAccount as this is a fairly common need for a lot of apps using ServiceAccounts.

Felt like because ServiceAccounts might be special in this regard, I copied `processer.ProcessObjMeta` and modified it to include an annotations template and value.

Feels a bit hacky and open to feedback as to what the right approach should be.