### PR TITLE
Extract args as values

### DIFF
--- a/examples/app/templates/deployment.yaml
+++ b/examples/app/templates/deployment.yaml
@@ -18,10 +18,7 @@ spec:
       {{- include "app.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-      - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
-        - --leader-elect
+      - args: {{- toYaml .Values.myapp.app.args | nindent 8 }}
         command:
         - /manager
         env:
@@ -65,9 +62,7 @@ spec:
           name: props
         - mountPath: /usr/share/nginx/html
           name: sample-pv-storage
-      - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --v=10
+      - args: {{- toYaml .Values.myapp.proxySidecar.args | nindent 8 }}
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}

--- a/examples/app/values.yaml
+++ b/examples/app/values.yaml
@@ -53,6 +53,10 @@ mySecretVars:
   var2: ""
 myapp:
   app:
+    args:
+    - --health-probe-bind-address=:8081
+    - --metrics-bind-address=127.0.0.1:8080
+    - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false
     image:
@@ -69,6 +73,9 @@ myapp:
     region: east
     type: user-node
   proxySidecar:
+    args:
+    - --secure-listen-address=0.0.0.0:8443
+    - --v=10
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.8.0

--- a/examples/operator/templates/deployment.yaml
+++ b/examples/operator/templates/deployment.yaml
@@ -25,11 +25,7 @@ spec:
       {{- include "operator.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-      - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
+      - args: {{- toYaml .Values.controllerManager.kubeRbacProxy.args | nindent 8 }}
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
@@ -40,10 +36,7 @@ spec:
         - containerPort: 8443
           name: https
         resources: {}
-      - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
-        - --leader-elect
+      - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
         command:
         - /manager
         env:

--- a/examples/operator/values.yaml
+++ b/examples/operator/values.yaml
@@ -2,10 +2,19 @@ configmapVars:
   var4: value for var4
 controllerManager:
   kubeRbacProxy:
+    args:
+    - --secure-listen-address=0.0.0.0:8443
+    - --upstream=http://127.0.0.1:8080/
+    - --logtostderr=true
+    - --v=10
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.8.0
   manager:
+    args:
+    - --health-probe-bind-address=:8081
+    - --metrics-bind-address=127.0.0.1:8080
+    - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -2,10 +2,11 @@ package deployment
 
 import (
 	"fmt"
-	"github.com/arttor/helmify/pkg/processor/pod"
 	"io"
 	"strings"
 	"text/template"
+
+	"github.com/arttor/helmify/pkg/processor/pod"
 
 	"github.com/arttor/helmify/pkg/helmify"
 	"github.com/arttor/helmify/pkg/processor"

--- a/pkg/processor/pod/pod.go
+++ b/pkg/processor/pod/pod.go
@@ -48,14 +48,30 @@ func ProcessSpec(objName string, appMeta helmify.AppMetadata, spec corev1.PodSpe
 		if err != nil {
 			return nil, nil, err
 		}
-		if !exists || len(res) == 0 {
-			continue
+		if exists && len(res) > 0 {
+			err = unstructured.SetNestedField(containers[i].(map[string]interface{}), fmt.Sprintf(`{{- toYaml .Values.%s.%s.resources | nindent 10 }}`, objName, containerName), "resources")
+			if err != nil {
+				return nil, nil, err
+			}
 		}
-		err = unstructured.SetNestedField(containers[i].(map[string]interface{}), fmt.Sprintf(`{{- toYaml .Values.%s.%s.resources | nindent 10 }}`, objName, containerName), "resources")
+
+		args, exists, err := unstructured.NestedStringSlice(containers[i].(map[string]interface{}), "args")
 		if err != nil {
 			return nil, nil, err
 		}
+		if exists && len(args) > 0 {
+			err = unstructured.SetNestedField(containers[i].(map[string]interface{}), fmt.Sprintf(`{{- toYaml .Values.%[1]s.%[2]s.args | nindent 8 }}`, objName, containerName), "args")
+			if err != nil {
+				return nil, nil, err
+			}
+
+			err = unstructured.SetNestedStringSlice(values, args, objName, containerName, "args")
+			if err != nil {
+				return nil, nil, fmt.Errorf("%w: unable to set deployment value field", err)
+			}
+		}
 	}
+
 	err = unstructured.SetNestedSlice(specMap, containers, "containers")
 	if err != nil {
 		return nil, nil, err

--- a/pkg/processor/pod/pod_test.go
+++ b/pkg/processor/pod/pod_test.go
@@ -1,0 +1,152 @@
+package pod
+
+import (
+	"testing"
+
+	"github.com/arttor/helmify/pkg/helmify"
+	"github.com/arttor/helmify/pkg/metadata"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/arttor/helmify/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	strDeployment = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        args:
+        - --test
+        - --arg
+        ports:
+        - containerPort: 80
+`
+
+	strDeploymentWithNoArgs = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+`
+)
+
+func Test_pod_Process(t *testing.T) {
+	t.Run("deployment with args", func(t *testing.T) {
+		var deploy appsv1.Deployment
+		obj := internal.GenerateObj(strDeployment)
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deploy)
+		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec)
+		assert.NoError(t, err)
+
+		assert.Equal(t, map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"args": "{{- toYaml .Values.nginx.nginx.args | nindent 8 }}",
+					"env": []interface{}{
+						map[string]interface{}{
+							"name":  "KUBERNETES_CLUSTER_DOMAIN",
+							"value": "{{ quote .Values.kubernetesClusterDomain }}",
+						},
+					},
+					"image": "{{ .Values.nginx.nginx.image.repository }}:{{ .Values.nginx.nginx.image.tag | default .Chart.AppVersion }}",
+					"name":  "nginx", "ports": []interface{}{
+						map[string]interface{}{
+							"containerPort": int64(80),
+						},
+					},
+					"resources": map[string]interface{}{},
+				},
+			},
+		}, specMap)
+
+		assert.Equal(t, helmify.Values{
+			"nginx": map[string]interface{}{
+				"nginx": map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository": "nginx",
+						"tag":        "1.14.2",
+					},
+					"args": []interface{}{
+						"--test",
+						"--arg",
+					},
+				},
+			},
+		}, tmpl)
+	})
+
+	t.Run("deployment with no args", func(t *testing.T) {
+		var deploy appsv1.Deployment
+		obj := internal.GenerateObj(strDeploymentWithNoArgs)
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deploy)
+		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec)
+		assert.NoError(t, err)
+
+		assert.Equal(t, map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"env": []interface{}{
+						map[string]interface{}{
+							"name":  "KUBERNETES_CLUSTER_DOMAIN",
+							"value": "{{ quote .Values.kubernetesClusterDomain }}",
+						},
+					},
+					"image": "{{ .Values.nginx.nginx.image.repository }}:{{ .Values.nginx.nginx.image.tag | default .Chart.AppVersion }}",
+					"name":  "nginx", "ports": []interface{}{
+						map[string]interface{}{
+							"containerPort": int64(80),
+						},
+					},
+					"resources": map[string]interface{}{},
+				},
+			},
+		}, specMap)
+
+		assert.Equal(t, helmify.Values{
+			"nginx": map[string]interface{}{
+				"nginx": map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository": "nginx",
+						"tag":        "1.14.2",
+					},
+				},
+			},
+		}, tmpl)
+	})
+
+}


### PR DESCRIPTION
This change extracts the args from a PodTemplate as values allowing configuring the passed-in parameters.