### PR TITLE
Handle images with digests

### DIFF
--- a/pkg/processor/pod/pod.go
+++ b/pkg/processor/pod/pod.go
@@ -166,7 +166,7 @@ func processPodSpec(name string, appMeta helmify.AppMetadata, pod *corev1.PodSpe
 }
 
 func processPodContainer(name string, appMeta helmify.AppMetadata, c corev1.Container, values *helmify.Values) (corev1.Container, error) {
-	index := strings.LastIndex(c.Image, ":")
+	index := strings.Index(c.Image, ":")
 	if index < 0 {
 		return c, fmt.Errorf("wrong image format: %q", c.Image)
 	}

--- a/pkg/processor/pod/pod_test.go
+++ b/pkg/processor/pod/pod_test.go
@@ -40,6 +40,30 @@ spec:
         - containerPort: 80
 `
 
+	strDeploymentWithTagAndDigest = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2@sha256:cb5c1bddd1b5665e1867a7fa1b5fa843a47ee433bbb75d4293888b71def53229
+        ports:
+        - containerPort: 80
+`
+
 	strDeploymentWithNoArgs = `
 apiVersion: apps/v1
 kind: Deployment
@@ -143,6 +167,45 @@ func Test_pod_Process(t *testing.T) {
 					"image": map[string]interface{}{
 						"repository": "nginx",
 						"tag":        "1.14.2",
+					},
+				},
+			},
+		}, tmpl)
+	})
+
+	t.Run("deployment with image tag and digest", func(t *testing.T) {
+		var deploy appsv1.Deployment
+		obj := internal.GenerateObj(strDeploymentWithTagAndDigest)
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deploy)
+		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec)
+		assert.NoError(t, err)
+
+		assert.Equal(t, map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"env": []interface{}{
+						map[string]interface{}{
+							"name":  "KUBERNETES_CLUSTER_DOMAIN",
+							"value": "{{ quote .Values.kubernetesClusterDomain }}",
+						},
+					},
+					"image": "{{ .Values.nginx.nginx.image.repository }}:{{ .Values.nginx.nginx.image.tag | default .Chart.AppVersion }}",
+					"name":  "nginx", "ports": []interface{}{
+						map[string]interface{}{
+							"containerPort": int64(80),
+						},
+					},
+					"resources": map[string]interface{}{},
+				},
+			},
+		}, specMap)
+
+		assert.Equal(t, helmify.Values{
+			"nginx": map[string]interface{}{
+				"nginx": map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository": "nginx",
+						"tag":        "1.14.2@sha256:cb5c1bddd1b5665e1867a7fa1b5fa843a47ee433bbb75d4293888b71def53229",
 					},
 				},
 			},


### PR DESCRIPTION
Previously, we were splitting image addresses at the _last_ instance of a colon; this had unfortunate side-effects when said address included a digest.

This change causes us to look for the _first_ instance of a colon, allowing both tag and digest to properly co-exist; we don't try to do anything fancier than that.