### PR TITLE
fix: don't strip newlines after the templated value

### DIFF
--- a/pkg/processor/service/service.go
+++ b/pkg/processor/service/service.go
@@ -27,7 +27,7 @@ spec:
 %[2]s
   {{- include "%[3]s.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.%[1]s.ports | toYaml | nindent 2 -}}`
+	{{- .Values.%[1]s.ports | toYaml | nindent 2 }}`
 )
 
 var svcGVC = schema.GroupVersionKind{


### PR DESCRIPTION
This issue ultimately presents as

```
ports:
- port: 8000
  protocol: TCP
  targetPort:8000---
apiVersion: policy/v1
kind PodDisruptionBudget
metadata:
```