### PR TITLE
Fixed the Indent length for CronJob 

### DIFF
--- a/examples/app/templates/cron-job.yaml
+++ b/examples/app/templates/cron-job.yaml
@@ -10,7 +10,8 @@ spec:
       template:
         spec:
           containers:
-          - command:
+          - args: {{- toYaml .Values.cronJob.hello.args | nindent 12 }}
+            command:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster

--- a/examples/app/templates/cron-job.yaml
+++ b/examples/app/templates/cron-job.yaml
@@ -22,6 +22,6 @@ spec:
               | default .Chart.AppVersion }}
             imagePullPolicy: {{ .Values.cronJob.hello.imagePullPolicy }}
             name: hello
-            resources: {}
+            resources: {{- toYaml .Values.cronJob.hello.resources | nindent 14 }}
           restartPolicy: OnFailure
   schedule: {{ .Values.cronJob.schedule | quote }}

--- a/examples/app/values.yaml
+++ b/examples/app/values.yaml
@@ -12,6 +12,9 @@ cronJob:
       repository: busybox
       tag: "1.28"
     imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        storage: 1Gi
   schedule: '* * * * *'
 fluentdElasticsearch:
   fluentdElasticsearch:

--- a/examples/app/values.yaml
+++ b/examples/app/values.yaml
@@ -6,6 +6,8 @@ batchJob:
       tag: 5.34.0
 cronJob:
   hello:
+    args:
+    - --health-probe-bind-address=:8081
     image:
       repository: busybox
       tag: "1.28"

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -75,7 +75,7 @@ func (c *appContext) CreateHelm(stop <-chan struct{}) error {
 		default:
 		}
 	}
-	return c.output.Create(c.config.ChartDir, c.config.ChartName, c.config.Crd, c.config.CertManagerAsSubchart, c.config.CertManagerVersion , templates, filenames)
+	return c.output.Create(c.config.ChartDir, c.config.ChartName, c.config.Crd, c.config.CertManagerAsSubchart, c.config.CertManagerVersion, templates, filenames)
 }
 
 func (c *appContext) process(obj *unstructured.Unstructured) (helmify.Template, error) {

--- a/pkg/processor/daemonset/daemonset.go
+++ b/pkg/processor/daemonset/daemonset.go
@@ -98,7 +98,7 @@ func (d daemonset) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstru
 	}
 
 	nameCamel := strcase.ToLowerCamel(name)
-	specMap, podValues, err := pod.ProcessSpec(nameCamel, appMeta, dae.Spec.Template.Spec)
+	specMap, podValues, err := pod.ProcessSpec(nameCamel, appMeta, dae.Spec.Template.Spec, 0)
 	if err != nil {
 		return true, nil, err
 	}

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -115,7 +115,7 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 	}
 
 	nameCamel := strcase.ToLowerCamel(name)
-	specMap, podValues, err := pod.ProcessSpec(nameCamel, appMeta, depl.Spec.Template.Spec)
+	specMap, podValues, err := pod.ProcessSpec(nameCamel, appMeta, depl.Spec.Template.Spec, 0)
 	if err != nil {
 		return true, nil, err
 	}

--- a/pkg/processor/job/cron.go
+++ b/pkg/processor/job/cron.go
@@ -105,7 +105,7 @@ func (p cron) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructure
 	}
 
 	// process job pod template:
-	podSpecMap, podValues, err := pod.ProcessSpec(nameCamelCase, appMeta, jobObj.Spec.JobTemplate.Spec.Template.Spec)
+	podSpecMap, podValues, err := pod.ProcessSpec(nameCamelCase, appMeta, jobObj.Spec.JobTemplate.Spec.Template.Spec, 4)
 	if err != nil {
 		return true, nil, err
 	}

--- a/pkg/processor/job/job.go
+++ b/pkg/processor/job/job.go
@@ -104,7 +104,7 @@ func (p job) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 		}
 	}
 	// process job pod template:
-	podSpecMap, podValues, err := pod.ProcessSpec(nameCamelCase, appMeta, jobObj.Spec.Template.Spec)
+	podSpecMap, podValues, err := pod.ProcessSpec(nameCamelCase, appMeta, jobObj.Spec.Template.Spec, 0)
 	if err != nil {
 		return true, nil, err
 	}

--- a/pkg/processor/pod/pod_test.go
+++ b/pkg/processor/pod/pod_test.go
@@ -118,7 +118,7 @@ func Test_pod_Process(t *testing.T) {
 		var deploy appsv1.Deployment
 		obj := internal.GenerateObj(strDeployment)
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deploy)
-		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec)
+		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec, 0)
 		assert.NoError(t, err)
 
 		assert.Equal(t, map[string]interface{}{
@@ -162,7 +162,7 @@ func Test_pod_Process(t *testing.T) {
 		var deploy appsv1.Deployment
 		obj := internal.GenerateObj(strDeploymentWithNoArgs)
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deploy)
-		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec)
+		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec, 0)
 		assert.NoError(t, err)
 
 		assert.Equal(t, map[string]interface{}{
@@ -201,7 +201,7 @@ func Test_pod_Process(t *testing.T) {
 		var deploy appsv1.Deployment
 		obj := internal.GenerateObj(strDeploymentWithTagAndDigest)
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deploy)
-		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec)
+		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec, 0)
 		assert.NoError(t, err)
 
 		assert.Equal(t, map[string]interface{}{
@@ -240,7 +240,7 @@ func Test_pod_Process(t *testing.T) {
 		var deploy appsv1.Deployment
 		obj := internal.GenerateObj(strDeploymentWithPort)
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &deploy)
-		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec)
+		specMap, tmpl, err := ProcessSpec("nginx", &metadata.Service{}, deploy.Spec.Template.Spec, 0)
 		assert.NoError(t, err)
 
 		assert.Equal(t, map[string]interface{}{

--- a/pkg/processor/statefulset/statefulset.go
+++ b/pkg/processor/statefulset/statefulset.go
@@ -108,7 +108,7 @@ func (d statefulset) Process(appMeta helmify.AppMetadata, obj *unstructured.Unst
 	}
 
 	// process pod spec:
-	podSpecMap, podValues, err := pod.ProcessSpec(nameCamel, appMeta, ssSpec.Template.Spec)
+	podSpecMap, podValues, err := pod.ProcessSpec(nameCamel, appMeta, ssSpec.Template.Spec, 0)
 	if err != nil {
 		return true, nil, err
 	}

--- a/test_data/sample-app.yaml
+++ b/test_data/sample-app.yaml
@@ -289,6 +289,9 @@ spec:
                 - date; echo Hello from the Kubernetes cluster
               args:
               - --health-probe-bind-address=:8081
+              resources:
+                requests:
+                  storage: 1Gi
           restartPolicy: OnFailure
 ---
 apiVersion: v1

--- a/test_data/sample-app.yaml
+++ b/test_data/sample-app.yaml
@@ -287,6 +287,8 @@ spec:
                 - /bin/sh
                 - -c
                 - date; echo Hello from the Kubernetes cluster
+              args:
+              - --health-probe-bind-address=:8081
           restartPolicy: OnFailure
 ---
 apiVersion: v1


### PR DESCRIPTION
## What did I change:
Change CronJob indent to 12 .

detailed:

If I put args in the CronJob like below:
```
apiVersion: batch/v1
kind: CronJob
metadata:
  name: cron-job
spec:
  schedule: "* * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          containers:
......
              args:
              - --leader-elect
```

And run pkg/app/app_e2e_test.go, an error occurs:
```shell
  app_e2e_test.go:58: 
        	Error Trace:	/Users/yuewenchen/GolandProjects/helmify/pkg/app/app_e2e_test.go:58
        	Error:      	Received unexpected error:
        	            	error converting YAML to JSON: yaml: line 17: did not find expected key
        	            	unable to parse YAML
        	            	helm.sh/helm/v3/pkg/lint/rules.validateYamlContent
        	            		/Users/yuewenchen/go/pkg/mod/helm.sh/helm/v3@v3.11.2/pkg/lint/rules/template.go:212
        	            	helm.sh/helm/v3/pkg/lint/rules.Templates
        	            		/Users/yuewenchen/go/pkg/mod/helm.sh/helm/v3@v3.11.2/pkg/lint/rules/template.go:146
        	            	helm.sh/helm/v3/pkg/lint.All
        	            		/Users/yuewenchen/go/pkg/mod/helm.sh/helm/v3@v3.11.2/pkg/lint/lint.go:34
        	            	helm.sh/helm/v3/pkg/action.lintChart
        	            		/Users/yuewenchen/go/pkg/mod/helm.sh/helm/v3@v3.11.2/pkg/action/lint.go:128
        	            	helm.sh/helm/v3/pkg/action.(*Lint).Run
        	            		/Users/yuewenchen/go/pkg/mod/helm.sh/helm/v3@v3.11.2/pkg/action/lint.go:62
        	            	github.com/arttor/helmify/pkg/app.TestApp
        	            		/Users/yuewenchen/GolandProjects/helmify/pkg/app/app_e2e_test.go:56
        	            	testing.tRunner
        	            		/Users/yuewenchen/go/sdk/go1.21.1/src/testing/testing.go:1595
        	            	runtime.goexit
        	            		/Users/yuewenchen/go/sdk/go1.21.1/src/runtime/asm_amd64.s:1650
        	Test:       	TestApp
--- FAIL: TestApp (0.06s)
```

If we checks the outputs of helm, we can see that the problem is caused by incorrect args indentation :
```shell
> helm template  app . --debug
---
# Source: app/templates/cron-job.yaml
apiVersion: batch/v1
kind: CronJob
spec:
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - args:
        - --leader-elect
```