### PR TITLE
Add Namespace to the metadata of generated resources in the Helm Chart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Usage:
 | -original-name            | Use the object's original name instead of adding the chart's release name as the common prefix.                                                                                                             | `helmify -original-name`            |
 | -cert-manager-as-subchart | Allows the user to install cert-manager as a subchart                                                                                                                                                       | `helmify -cert-manager-as-subchart` |
 | -cert-manager-version     | Allows the user to specify cert-manager subchart version. Only useful with cert-manager-as-subchart. (default "v1.12.2")                                                                                    | `helmify -cert-manager-as-subchart` |
+| -preserve-ns              | Allows users to use the object's original namespace instead of adding all the resources to a common namespace. (default "false")                                                                                    | `helmify -preserve-ns` |
 ## Status
 Supported k8s resources:
 - Deployment, DaemonSet, StatefulSet

--- a/cmd/helmify/flags.go
+++ b/cmd/helmify/flags.go
@@ -54,7 +54,7 @@ func (i *arrayFlags) Set(value string) error {
 func ReadFlags() config.Config {
 	files := arrayFlags{}
 	result := config.Config{}
-	var h, help, version, crd bool
+	var h, help, version, crd , preservens bool
 	flag.BoolVar(&h, "h", false, "Print help. Example: helmify -h")
 	flag.BoolVar(&help, "help", false, "Print help. Example: helmify -help")
 	flag.BoolVar(&version, "version", false, "Print helmify version. Example: helmify -version")
@@ -68,7 +68,7 @@ func ReadFlags() config.Config {
 	flag.BoolVar(&result.FilesRecursively, "r", false, "Scan dirs from -f option recursively")
 	flag.BoolVar(&result.OriginalName, "original-name", false, "Use the object's original name instead of adding the chart's release name as the common prefix.")
 	flag.Var(&files, "f", "File or directory containing k8s manifests")
-
+	flag.BoolVar(&preservens, "preserve-ns", false, "Use the object's original namespace instead of adding all the resources to a common namespace")
 	flag.Parse()
 	if h || help {
 		fmt.Print(helpText)
@@ -86,6 +86,9 @@ func ReadFlags() config.Config {
 	}
 	if crd {
 		result.Crd = crd
+	}
+	if preservens {
+		result.PreserveNs = true
 	}
 	result.Files = files
 	return result

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	FilesRecursively bool
 	// OriginalName retains Kubernetes resource's original name
 	OriginalName bool
+	// PreserveNs retains the namespaces on the Kubernetes manifests
+	PreserveNs bool
 }
 
 func (c *Config) Validate() error {

--- a/pkg/processor/meta.go
+++ b/pkg/processor/meta.go
@@ -16,6 +16,7 @@ const metaTemplate = `apiVersion: %[1]s
 kind: %[2]s
 metadata:
   name: %[3]s
+  namespace: %[7]s  # Include the namespace here	
   labels:
 %[5]s
   {{- include "%[4]s.labels" . | nindent 4 }}
@@ -80,6 +81,7 @@ func ProcessObjMeta(appMeta helmify.AppMetadata, obj *unstructured.Unstructured,
 			return "", err
 		}
 	}
+	ns := obj.GetNamespace()
 
 	templatedName := appMeta.TemplatedName(obj.GetName())
 	apiVersion, kind := obj.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
@@ -100,7 +102,7 @@ func ProcessObjMeta(appMeta helmify.AppMetadata, obj *unstructured.Unstructured,
 		annotations = fmt.Sprintf(annotationsTemplate, name, kind)
 	}
 
-	metaStr = fmt.Sprintf(metaTemplate, apiVersion, kind, templatedName, appMeta.ChartName(), labels, annotations)
+	metaStr = fmt.Sprintf(metaTemplate, apiVersion, kind, templatedName, appMeta.ChartName(), labels, annotations, ns)
 	metaStr = strings.Trim(metaStr, " \n")
 	metaStr = strings.ReplaceAll(metaStr, "\n\n", "\n")
 	return metaStr, nil

--- a/pkg/processor/meta.go
+++ b/pkg/processor/meta.go
@@ -16,7 +16,7 @@ const metaTemplate = `apiVersion: %[1]s
 kind: %[2]s
 metadata:
   name: %[3]s
-  %[7]s  	
+%[7]s
   labels:
 %[5]s
   {{- include "%[4]s.labels" . | nindent 4 }}
@@ -82,8 +82,8 @@ func ProcessObjMeta(appMeta helmify.AppMetadata, obj *unstructured.Unstructured,
 		}
 	}
 
-	if obj.GetNamespace() != "" {
-		namespace, err = yamlformat.Marshal(map[string]interface{}{"namespace": obj.GetNamespace()}, 0)
+	if (obj.GetNamespace() != "") && (appMeta.Config().PreserveNs){
+		namespace, err = yamlformat.Marshal(map[string]interface{}{"namespace": obj.GetNamespace()}, 2)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Updated the repo to include the namespace in the metadata of the helm chart generated.
This is to overcome the enhancement requested in this [issue](https://github.com/arttor/helmify/issues/143).

Tested by running the test mentioned in the readme documentation.
