### PR TITLE
add support for pod level securityContext

### DIFF
--- a/examples/app/templates/deployment.yaml
+++ b/examples/app/templates/deployment.yaml
@@ -87,8 +87,7 @@ spec:
         name: init-container
         resources: {}
       nodeSelector: {{- toYaml .Values.myapp.nodeSelector | nindent 8 }}
-      securityContext:
-        runAsNonRoot: true
+      securityContext: {{- toYaml .Values.myapp.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:

--- a/examples/app/values.yaml
+++ b/examples/app/values.yaml
@@ -76,6 +76,10 @@ myapp:
   nodeSelector:
     region: east
     type: user-node
+  podSecurityContext:
+    fsGroup: 20000
+    runAsNonRoot: true
+    runAsUser: 65532
   proxySidecar:
     args:
     - --secure-listen-address=0.0.0.0:8443

--- a/examples/operator/templates/deployment.yaml
+++ b/examples/operator/templates/deployment.yaml
@@ -87,8 +87,8 @@ spec:
       imagePullSecrets:
       - name: {{ include "operator.fullname" . }}-secret-registry-credentials
       nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
-      securityContext:
-        runAsNonRoot: true
+      securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
+        8 }}
       serviceAccountName: {{ include "operator.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
       topologySpreadConstraints:

--- a/examples/operator/values.yaml
+++ b/examples/operator/values.yaml
@@ -43,6 +43,8 @@ controllerManager:
   nodeSelector:
     region: east
     type: user-node
+  podSecurityContext:
+    runAsNonRoot: true
   replicas: 1
   serviceAccount:
     annotations:

--- a/pkg/processor/pod/pod.go
+++ b/pkg/processor/pod/pod.go
@@ -66,12 +66,12 @@ func ProcessSpec(objName string, appMeta helmify.AppMetadata, spec corev1.PodSpe
 			return nil, nil, err
 		}
 		if len(securityContextMap) > 0 {
-			err = unstructured.SetNestedField(specMap, fmt.Sprintf(`{{- toYaml .Values.%[1]s.podSecurityPolicy | nindent 8 }}`, objName), "securityContext")
+			err = unstructured.SetNestedField(specMap, fmt.Sprintf(`{{- toYaml .Values.%[1]s.podSecurityContext | nindent 8 }}`, objName), "securityContext")
 			if err != nil {
 				return nil, nil, err
 			}
 
-			err = unstructured.SetNestedField(values, securityContextMap, objName, "podSecurityPolicy")
+			err = unstructured.SetNestedField(values, securityContextMap, objName, "podSecurityContext")
 			if err != nil {
 				return nil, nil, fmt.Errorf("%w: unable to set deployment value field", err)
 			}

--- a/pkg/processor/pod/pod_test.go
+++ b/pkg/processor/pod/pod_test.go
@@ -321,12 +321,12 @@ func Test_pod_Process(t *testing.T) {
 					"resources": map[string]interface{}{},
 				},
 			},
-			"securityContext": "{{- toYaml .Values.nginx.podSecurityPolicy | nindent 8 }}",
+			"securityContext": "{{- toYaml .Values.nginx.podSecurityContext | nindent 8 }}",
 		}, specMap)
 
 		assert.Equal(t, helmify.Values{
 			"nginx": map[string]interface{}{
-				"podSecurityPolicy": map[string]interface{}{
+				"podSecurityContext": map[string]interface{}{
 					"fsGroup":      int64(20000),
 					"runAsGroup":   int64(30000),
 					"runAsNonRoot": true,

--- a/test_data/sample-app.yaml
+++ b/test_data/sample-app.yaml
@@ -81,6 +81,8 @@ spec:
               name: https
       securityContext:
         runAsNonRoot: true
+        fsGroup: 20000
+        runAsUser: 65532
       nodeSelector:
         region: east
         type: user-node


### PR DESCRIPTION
Hi! I have created this PR to check if addition of templating for  Pod-level SecurityContext could be accepted.
I find this useful as, depending on who is using your helm Chart, they may need to define a more or less strict securityContext depending on their security policies.

Closes #149 