### PR TITLE
added parser for loadBalancerSourceRanges field

### DIFF
--- a/examples/app/templates/myapp-lb-service.yaml
+++ b/examples/app/templates/myapp-lb-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}-myapp-lb-service
+  labels:
+    app: myapp
+  {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.myappLbService.type }}
+  selector:
+    app: myapp
+    {{- include "app.selectorLabels" . | nindent 4 }}
+  ports:
+  {{- .Values.myappLbService.ports | toYaml | nindent 2 }}
+  loadBalancerSourceRanges:
+  {{ - .Values.myappLbService.loadBalancerSourceRanges | toYaml | nindent 2 }}

--- a/examples/app/values.yaml
+++ b/examples/app/values.yaml
@@ -89,6 +89,14 @@ myapp:
       tag: v0.8.0
   replicas: 3
   revisionHistoryLimit: 5
+myappLbService:
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  type: LoadBalancer
 myappPdb:
   minAvailable: 2
 myappService:

--- a/test_data/sample-app.yaml
+++ b/test_data/sample-app.yaml
@@ -138,6 +138,24 @@ spec:
   selector:
     app: myapp
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myapp
+  name: myapp-lb-service
+  namespace: my-ns
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app: myapp
+  type: LoadBalancer
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
To close issue #146

I added the code to parse the field `spec.loadBalancerSourceRanges` if is present and in order to check the result I also added a new service in `test_data/sample-app.yaml`. In this way there are the two cases, the one without the field (that has no changes) and the new one with the field