### PR TITLE
change in flags and templates to implement optional secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,18 @@ jobs:
         cache: false
 
     - name: Fmt
-      run: go fmt ./...
-
+      run: |
+          # Run gofmt in "diff" mode to check for unformatted code
+          UNFORMATTED_FILES=$(gofmt -l .)
+          # Check if any files are unformatted
+          if [[ -n "$UNFORMATTED_FILES" ]]; then
+            echo "::error::The following Go files are not formatted correctly:"
+            echo "$UNFORMATTED_FILES"  # List unformatted files in the log
+            echo "::error::Please format your Go code by running \`go fmt ./...\` and commit the changes."
+            exit 1  # Fail the check
+          else
+            echo "All Go files are properly formatted."
+          fi
     - name: Vet
       run: go vet ./...
 
@@ -33,6 +43,24 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.54
+# Generate example charts
+    - name: Generate example charts
+      run: |
+          cat test_data/sample-app.yaml | go run ./cmd/helmify examples/app
+          cat test_data/k8s-operator-kustomize.output | go run ./cmd/helmify examples/operator
+    - name: Check that chart examples were commited
+      run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            # Capture the list of uncommitted files
+            UNCOMMITTED_FILES=$(git status --porcelain)
+            echo "::error::Chart examples generation step has uncommitted changes: $UNCOMMITTED_FILES
+          Please run following commands and commit the results:
+          - \`cat test_data/sample-app.yaml | go run ./cmd/helmify examples/app\`
+          - \`cat test_data/k8s-operator-kustomize.output | go run ./cmd/helmify examples/operator\`"
+            exit 1
+          else
+            echo "Chart examples generation check passed. No uncommitted changes."
+          fi
 # Dry-run generated charts in cluster
     - name: Install k8s cluster
       uses: helm/kind-action@v1.4.0

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Usage:
 | -cert-manager-version     | Allows the user to specify cert-manager subchart version. Only useful with cert-manager-as-subchart. (default "v1.12.2")                                                                                    | `helmify -cert-manager-version=v1.12.2`    |
 | -cert-manager-install-crd     | Allows the user to install cert-manager CRD as part of the cert-manager subchart.(default "true")                                                                                                           | `helmify -cert-manager-install-crd` |
 | -preserve-ns              | Allows users to use the object's original namespace instead of adding all the resources to a common namespace. (default "false")                                                                            | `helmify -preserve-ns`              |
+| -add-webhook-option | Adds an option to enable/disable webhook installation  | `helmify -add-webhook-option`|
 ## Status
 Supported k8s resources:
 - Deployment, DaemonSet, StatefulSet

--- a/README.md
+++ b/README.md
@@ -162,3 +162,26 @@ go test ./...
 Beside unit-tests, project contains e2e test `pkg/app/app_e2e_test.go`.
 It's a go test, which uses `test_data/*` to generate a chart in temporary directory. 
 Then runs `helm lint --strict` to check if generated chart is valid.
+
+## Contribute
+
+Following rules will help changes to be accepted faster:
+- For more than one-line bugfixes consider creating an issue with bug description or feature request
+- For feature request try to think about and cover following topics (when applicable):
+  - Motivation: why feature is needed? Which problem does it solve? What is current workaround?
+  - Backward-compatibility: existing users expect that after upgrading helmify version their existing generated charts wont be changed without consent.
+- For bugfix PR consider adding example to [/test_data](./test_data/) source yamls reproducing bug.
+
+### Contribution flow
+
+Check list before submitting PR:
+1. Run `go fmt ./...`
+2. Run tests `go test ./...`
+3. Update chart examples:
+   ```shell
+   cat test_data/sample-app.yaml | go run ./cmd/helmify examples/app
+   ```
+   ```shell
+   cat test_data/k8s-operator-kustomize.output | go run ./cmd/helmify examples/operator
+   ```
+4. In case of long commit history (more than 3) squash local commits into one

--- a/cmd/helmify/flags.go
+++ b/cmd/helmify/flags.go
@@ -72,6 +72,8 @@ func ReadFlags() config.Config {
 	flag.Var(&files, "f", "File or directory containing k8s manifests")
 	flag.Var(&optionalSecrets, "optional-secrets", "List of secrets to be templated as optional (their values will not be required).")
 	flag.BoolVar(&preservens, "preserve-ns", false, "Use the object's original namespace instead of adding all the resources to a common namespace")
+	flag.BoolVar(&result.AddWebhookOption, "add-webhook-option", false, "Allows the user to add webhook option in values.yaml")
+
 	flag.Parse()
 	if h || help {
 		fmt.Print(helpText)

--- a/cmd/helmify/flags.go
+++ b/cmd/helmify/flags.go
@@ -53,6 +53,7 @@ func (i *arrayFlags) Set(value string) error {
 // ReadFlags command-line flags into app config.
 func ReadFlags() config.Config {
 	files := arrayFlags{}
+	optionalSecrets := arrayFlags{}
 	result := config.Config{}
 	var h, help, version, crd, preservens bool
 	flag.BoolVar(&h, "h", false, "Print help. Example: helmify -h")
@@ -69,6 +70,7 @@ func ReadFlags() config.Config {
 	flag.BoolVar(&result.FilesRecursively, "r", false, "Scan dirs from -f option recursively")
 	flag.BoolVar(&result.OriginalName, "original-name", false, "Use the object's original name instead of adding the chart's release name as the common prefix.")
 	flag.Var(&files, "f", "File or directory containing k8s manifests")
+	flag.Var(&optionalSecrets, "optional-secrets", "List of secrets to be templated as optional (their values will not be required).")
 	flag.BoolVar(&preservens, "preserve-ns", false, "Use the object's original namespace instead of adding all the resources to a common namespace")
 	flag.Parse()
 	if h || help {
@@ -92,5 +94,6 @@ func ReadFlags() config.Config {
 		result.PreserveNs = true
 	}
 	result.Files = files
+	result.OptionalSecrets = optionalSecrets
 	return result
 }

--- a/examples/app/templates/deployment.yaml
+++ b/examples/app/templates/deployment.yaml
@@ -33,6 +33,14 @@ spec:
             secretKeyRef:
               key: VAR2
               name: {{ include "app.fullname" . }}-my-secret-vars
+        - name: APP_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/name']
+        - name: INSTANCE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/instance']
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.myapp.app.image.repository }}:{{ .Values.myapp.app.image.tag
@@ -78,7 +86,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - echo Initializing container...
+        - echo 'Initializing container...'
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}

--- a/examples/app/templates/myapp-lb-service.yaml
+++ b/examples/app/templates/myapp-lb-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}-myapp-lb-service
+  labels:
+    app: myapp
+  {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.myappLbService.type }}
+  selector:
+    app: myapp
+    {{- include "app.selectorLabels" . | nindent 4 }}
+  ports:
+  {{- .Values.myappLbService.ports | toYaml | nindent 2 }}
+  loadBalancerSourceRanges:
+  {{ - .Values.myappLbService.loadBalancerSourceRanges | toYaml | nindent 2 }}

--- a/examples/app/templates/myapp-lb-service.yaml
+++ b/examples/app/templates/myapp-lb-service.yaml
@@ -13,4 +13,4 @@ spec:
   ports:
   {{- .Values.myappLbService.ports | toYaml | nindent 2 }}
   loadBalancerSourceRanges:
-  {{ - .Values.myappLbService.loadBalancerSourceRanges | toYaml | nindent 2 }}
+  {{- .Values.myappLbService.loadBalancerSourceRanges | toYaml | nindent 2 }}

--- a/examples/app/templates/myapp-service.yaml
+++ b/examples/app/templates/myapp-service.yaml
@@ -9,6 +9,6 @@ spec:
   type: {{ .Values.myappService.type }}
   selector:
     app: myapp
-  {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- include "app.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.myappService.ports | toYaml | nindent 2 }}
+  {{- .Values.myappService.ports | toYaml | nindent 2 }}

--- a/examples/app/templates/nginx.yaml
+++ b/examples/app/templates/nginx.yaml
@@ -9,6 +9,6 @@ spec:
   type: {{ .Values.nginx.type }}
   selector:
     app: nginx
-  {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- include "app.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.nginx.ports | toYaml | nindent 2 }}
+  {{- .Values.nginx.ports | toYaml | nindent 2 }}

--- a/examples/app/values.yaml
+++ b/examples/app/values.yaml
@@ -89,6 +89,14 @@ myapp:
       tag: v0.8.0
   replicas: 3
   revisionHistoryLimit: 5
+myappLbService:
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  type: LoadBalancer
 myappPdb:
   minAvailable: 2
 myappService:

--- a/examples/operator/templates/metrics-service.yaml
+++ b/examples/operator/templates/metrics-service.yaml
@@ -9,6 +9,6 @@ spec:
   type: {{ .Values.metricsService.type }}
   selector:
     control-plane: controller-manager
-  {{- include "operator.selectorLabels" . | nindent 4 }}
+    {{- include "operator.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.metricsService.ports | toYaml | nindent 2 }}
+  {{- .Values.metricsService.ports | toYaml | nindent 2 }}

--- a/examples/operator/templates/webhook-service.yaml
+++ b/examples/operator/templates/webhook-service.yaml
@@ -8,6 +8,6 @@ spec:
   type: {{ .Values.webhookService.type }}
   selector:
     control-plane: controller-manager
-  {{- include "operator.selectorLabels" . | nindent 4 }}
+    {{- include "operator.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.webhookService.ports | toYaml | nindent 2 }}
+  {{- .Values.webhookService.ports | toYaml | nindent 2 }}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -40,6 +41,8 @@ type Config struct {
 	OriginalName bool
 	// PreserveNs retains the namespaces on the Kubernetes manifests
 	PreserveNs bool
+	// OptionalSecrets - list of secrets that are optional and should only be generated if values are given
+	OptionalSecrets []string
 }
 
 func (c *Config) Validate() error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	PreserveNs bool
 	// OptionalSecrets - list of secrets that are optional and should only be generated if values are given
 	OptionalSecrets []string
+	// AddWebhookOption enables the generation of a webhook option in values.yamlß
+	AddWebhookOption bool
 }
 
 func (c *Config) Validate() error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	OptionalSecrets []string
 	// AddWebhookOption enables the generation of a webhook option in values.yamlß
 	AddWebhookOption bool
+	// OptionalSecrets - list of secrets that are optional and should only be generated if values are given
+	OptionalSecrets []string
 }
 
 func (c *Config) Validate() error {

--- a/pkg/helmify/values.go
+++ b/pkg/helmify/values.go
@@ -1,10 +1,11 @@
 package helmify
 
 import (
-	"dario.cat/mergo"
 	"fmt"
 	"strconv"
 	"strings"
+
+	"dario.cat/mergo"
 
 	"github.com/iancoleman/strcase"
 
@@ -71,12 +72,15 @@ func (v *Values) AddYaml(value interface{}, indent int, newLine bool, name ...st
 
 // AddSecret - adds empty value to values and returns its helm template representation {{ required "<valueName>" .Values.<valueName> }}.
 // Set toBase64=true for Secret data to be base64 encoded and set false for Secret stringData.
-func (v *Values) AddSecret(toBase64 bool, name ...string) (string, error) {
+func (v *Values) AddSecret(toBase64 bool, optionalSecret bool, name ...string) (string, error) {
 	name = toCamelCase(name)
 	nameStr := strings.Join(name, ".")
-	err := unstructured.SetNestedField(*v, "", name...)
-	if err != nil {
-		return "", fmt.Errorf("%w: unable to set value: %v", err, nameStr)
+	var err error = nil
+	if !optionalSecret {
+		err = unstructured.SetNestedField(*v, "", name...)
+		if err != nil {
+			return "", fmt.Errorf("%w: unable to set value: %v", err, nameStr)
+		}
 	}
 	res := fmt.Sprintf(`{{ required "%[1]s is required" .Values.%[1]s`, nameStr)
 	if toBase64 {

--- a/pkg/helmify/values_test.go
+++ b/pkg/helmify/values_test.go
@@ -71,13 +71,13 @@ func TestValues_Add(t *testing.T) {
 func TestValues_AddSecret(t *testing.T) {
 	t.Run("add base64 enc secret", func(t *testing.T) {
 		testVal := Values{}
-		res, err := testVal.AddSecret(true, "a", "b")
+		res, err := testVal.AddSecret(true, true, "a", "b")
 		assert.NoError(t, err)
 		assert.Contains(t, res, "b64enc")
 	})
 	t.Run("add not encoded secret", func(t *testing.T) {
 		testVal := Values{}
-		res, err := testVal.AddSecret(false, "a", "b")
+		res, err := testVal.AddSecret(false, true, "a", "b")
 		assert.NoError(t, err)
 		assert.NotContains(t, res, "b64enc")
 	})

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -129,7 +130,8 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 		return true, nil, err
 	}
 
-	spec = strings.ReplaceAll(spec, "'", "")
+	match := regexp.MustCompile(`'({{((.*|.*\n.*))}}.*)'`)
+	spec = match.ReplaceAllString(spec, "${1}")
 
 	return true, &result{
 		values: values,

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -130,8 +130,7 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 		return true, nil, err
 	}
 
-	r := regexp.MustCompile(`'({{((.*|.*\n.*))}}.*)'`)
-	spec = r.ReplaceAllString(spec, "${1}")
+	spec = replaceSingleQuotes(spec)
 
 	return true, &result{
 		values: values,
@@ -153,6 +152,11 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 			Spec:                 spec,
 		},
 	}, nil
+}
+
+func replaceSingleQuotes(s string) string {
+	r := regexp.MustCompile(`'({{((.*|.*\n.*))}}.*)'`)
+	return r.ReplaceAllString(s, "${1}")
 }
 
 func processReplicas(name string, deployment *appsv1.Deployment, values *helmify.Values) (string, error) {

--- a/pkg/processor/deployment/deployment.go
+++ b/pkg/processor/deployment/deployment.go
@@ -130,8 +130,8 @@ func (d deployment) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstr
 		return true, nil, err
 	}
 
-	match := regexp.MustCompile(`'({{((.*|.*\n.*))}}.*)'`)
-	spec = match.ReplaceAllString(spec, "${1}")
+	r := regexp.MustCompile(`'({{((.*|.*\n.*))}}.*)'`)
+	spec = r.ReplaceAllString(spec, "${1}")
 
 	return true, &result{
 		values: values,

--- a/pkg/processor/deployment/deployment_test.go
+++ b/pkg/processor/deployment/deployment_test.go
@@ -134,3 +134,84 @@ func Test_deployment_Process(t *testing.T) {
 		assert.Equal(t, false, processed)
 	})
 }
+
+var singleQuotesTest = []struct {
+	input    string
+	expected string
+}{
+	{
+		"{{ .Values.x }}",
+		"{{ .Values.x }}",
+	},
+	{
+		"'{{ .Values.x }}'",
+		"{{ .Values.x }}",
+	},
+	{
+		"'{{ .Values.x }}:{{ .Values.y }}'",
+		"{{ .Values.x }}:{{ .Values.y }}",
+	},
+	{
+		"'{{ .Values.x }}:{{ .Values.y \n\t| default .Chart.AppVersion}}'",
+		"{{ .Values.x }}:{{ .Values.y \n\t| default .Chart.AppVersion}}",
+	},
+	{
+		"echo 'x'",
+		"echo 'x'",
+	},
+	{
+		"abcd: x.y['x/y']",
+		"abcd: x.y['x/y']",
+	},
+	{
+		"abcd: x.y[\"'{{}}'\"]",
+		"abcd: x.y[\"{{}}\"]",
+	},
+	{
+		"image: '{{ .Values.x }}'",
+		"image: {{ .Values.x }}",
+	},
+	{
+		"'{{ .Values.x }} y'",
+		"{{ .Values.x }} y",
+	},
+	{
+		"\t\t- mountPath: './x.y'",
+		"\t\t- mountPath: './x.y'",
+	},
+	{
+		"'{{}}'",
+		"{{}}",
+	},
+	{
+		"'{{ {nested} }}'",
+		"{{ {nested} }}",
+	},
+	{
+		"'{{ '{{nested}}' }}'",
+		"{{ '{{nested}}' }}",
+	},
+	{
+		"'{{ unbalanced }'",
+		"'{{ unbalanced }'",
+	},
+	{
+		"'{{\nincomplete content'",
+		"'{{\nincomplete content'",
+	},
+	{
+		"'{{ @#$%^&*() }}'",
+		"{{ @#$%^&*() }}",
+	},
+}
+
+func Test_replaceSingleQuotes(t *testing.T) {
+	for _, tt := range singleQuotesTest {
+		t.Run(tt.input, func(t *testing.T) {
+			s := replaceSingleQuotes(tt.input)
+			if s != tt.expected {
+				t.Errorf("got %q, want %q", s, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/processor/deployment/deployment_test.go
+++ b/pkg/processor/deployment/deployment_test.go
@@ -74,6 +74,10 @@ spec:
               resource: limits.cpu
         - name: VAR5
           value: "123"
+        - name: VAR6
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/something']
         image: controller:latest
         livenessProbe:
           httpGet:

--- a/pkg/processor/meta.go
+++ b/pkg/processor/meta.go
@@ -82,7 +82,7 @@ func ProcessObjMeta(appMeta helmify.AppMetadata, obj *unstructured.Unstructured,
 		}
 	}
 
-	if (obj.GetNamespace() != "") && (appMeta.Config().PreserveNs){
+	if (obj.GetNamespace() != "") && (appMeta.Config().PreserveNs) {
 		namespace, err = yamlformat.Marshal(map[string]interface{}{"namespace": obj.GetNamespace()}, 2)
 		if err != nil {
 			return "", err

--- a/pkg/processor/secret/secret.go
+++ b/pkg/processor/secret/secret.go
@@ -37,6 +37,8 @@ import (
 {{- if .Optional }}
 {{ -end }}`
 */
+// Template uses << and >> as delimiters because if we used the default ones "{{" and ""}}"
+// we would not be able ton insert {{- end }} in the template.
 var secretTempl, _ = template.New("secret").Delims("<<", ">>").Parse(
 	`<<- if .Optional >>
 << .Optional >>

--- a/pkg/processor/service/service.go
+++ b/pkg/processor/service/service.go
@@ -33,7 +33,7 @@ spec:
 const (
 	lbSourceRangesTempSpec = `
   loadBalancerSourceRanges:
-  {{ - .Values.%[1]s.loadBalancerSourceRanges | toYaml | nindent 2 }}`
+  {{- .Values.%[1]s.loadBalancerSourceRanges | toYaml | nindent 2 }}`
 )
 
 var svcGVC = schema.GroupVersionKind{

--- a/pkg/processor/service/service.go
+++ b/pkg/processor/service/service.go
@@ -25,9 +25,9 @@ spec:
   type: {{ .Values.%[1]s.type }}
   selector:
 %[2]s
-  {{- include "%[3]s.selectorLabels" . | nindent 4 }}
+    {{- include "%[3]s.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.%[1]s.ports | toYaml | nindent 2 }}`
+  {{- .Values.%[1]s.ports | toYaml | nindent 2 }}`
 )
 
 var svcGVC = schema.GroupVersionKind{

--- a/pkg/processor/service/service.go
+++ b/pkg/processor/service/service.go
@@ -94,8 +94,12 @@ func (r svc) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 		}
 		ports[i] = pMap
 	}
+
 	_ = unstructured.SetNestedSlice(values, ports, shortNameCamel, "ports")
 	res := meta + fmt.Sprintf(svcTempSpec, shortNameCamel, selector, appMeta.ChartName())
+	if shortNameCamel == "webhookService" && appMeta.Config().AddWebhookOption {
+		res = fmt.Sprintf("{{- if .Values.webhook.enabled }}\n%s\n{{- end }}", res)
+	}
 	return true, &result{
 		name:   shortName,
 		data:   res,

--- a/pkg/processor/webhook/validating.go
+++ b/pkg/processor/webhook/validating.go
@@ -65,7 +65,15 @@ func (w vwh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 	}
 	certName = strings.TrimPrefix(certName, appMeta.Namespace()+"/")
 	certName = appMeta.TrimName(certName)
-	res := fmt.Sprintf(vwhTempl, appMeta.ChartName(), name, certName, string(webhooks))
+	tmpl := vwhTempl
+	values := helmify.Values{}
+	if appMeta.Config().AddWebhookOption {
+		// Add webhook.enabled value to values.yaml
+		_, _ = values.Add(true, "webhook", "enabled")
+
+		tmpl = fmt.Sprintf("%s\n%s\n%s", WebhookHeader, mwhTempl, WebhookFooter)
+	}
+	res := fmt.Sprintf(tmpl, appMeta.ChartName(), name, certName, string(webhooks))
 	return true, &vwhResult{
 		name: name,
 		data: []byte(res),
@@ -73,8 +81,9 @@ func (w vwh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 }
 
 type vwhResult struct {
-	name string
-	data []byte
+	name   string
+	data   []byte
+	values helmify.Values
 }
 
 func (r *vwhResult) Filename() string {
@@ -82,7 +91,7 @@ func (r *vwhResult) Filename() string {
 }
 
 func (r *vwhResult) Values() helmify.Values {
-	return helmify.Values{}
+	return r.values
 }
 
 func (r *vwhResult) Write(writer io.Writer) error {

--- a/test_data/sample-app.yaml
+++ b/test_data/sample-app.yaml
@@ -49,6 +49,14 @@ spec:
                 secretKeyRef:
                   name: my-secret-vars
                   key: VAR2
+            - name: APP_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/name']
+            - name: INSTANCE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/instance']
           image: controller:latest
           livenessProbe:
             httpGet:

--- a/test_data/sample-app.yaml
+++ b/test_data/sample-app.yaml
@@ -138,6 +138,24 @@ spec:
   selector:
     app: myapp
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myapp
+  name: myapp-lb-service
+  namespace: my-ns
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app: myapp
+  type: LoadBalancer
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
Adding flag -optional-secrets which receives a list of secrets that will be generated in a non required way. That is, they will be contained inside a Helm template which will check for the existance of values related to the secret. If no value is present, the secret will not be rendered.