### PR TITLE
Fix: escape {{}} in CRDs to prevent Helm templating errors

### DIFF
--- a/pkg/processor/crd/crd.go
+++ b/pkg/processor/crd/crd.go
@@ -111,13 +111,21 @@ func (c crd) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 		return true, nil, fmt.Errorf("%w: unable to cast to crd spec", err)
 	}
 
+	replacements := make(map[string]string)
 	if spec.Conversion != nil {
 		conv := spec.Conversion
 		if conv.Strategy == v1.WebhookConverter {
 			wh := conv.Webhook
 			if wh != nil && wh.ClientConfig != nil && wh.ClientConfig.Service != nil {
-				wh.ClientConfig.Service.Name = appMeta.TemplatedName(wh.ClientConfig.Service.Name)
-				wh.ClientConfig.Service.Namespace = strings.ReplaceAll(wh.ClientConfig.Service.Namespace, appMeta.Namespace(), `{{ .Release.Namespace }}`)
+				// Use placeholders starting with '*' to force quoting in YAML
+				namePlaceholder := "*__HELMIFY_NAME_PLACEHOLDER__"
+				nsPlaceholder := "*__HELMIFY_NS_PLACEHOLDER__"
+
+				replacements[namePlaceholder] = appMeta.TemplatedName(wh.ClientConfig.Service.Name)
+				wh.ClientConfig.Service.Name = namePlaceholder
+
+				replacements[nsPlaceholder] = strings.ReplaceAll(wh.ClientConfig.Service.Namespace, appMeta.Namespace(), `{{ .Release.Namespace }}`)
+				wh.ClientConfig.Service.Namespace = nsPlaceholder
 			}
 		}
 	}
@@ -126,7 +134,17 @@ func (c crd) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 	specYaml = yamlformat.Indent(specYaml, 2)
 	specYaml = bytes.TrimRight(specYaml, "\n ")
 
-	res := fmt.Sprintf(crdTeml, obj.GetName(), appMeta.ChartName(), annotations, labels, string(specYaml))
+	specStr := string(specYaml)
+	// Escape {{ and }} to {{ "{{" }} and {{ "}}" }} to prevent Helm from interpreting them
+	replacer := strings.NewReplacer("{{", `{{ "{{" }}`, "}}", `{{ "}}" }}`)
+	specStr = replacer.Replace(specStr)
+
+	// Restore placeholders with actual Helm templates
+	for k, v := range replacements {
+		specStr = strings.ReplaceAll(specStr, k, v)
+	}
+
+	res := fmt.Sprintf(crdTeml, obj.GetName(), appMeta.ChartName(), annotations, labels, specStr)
 	res = strings.ReplaceAll(res, "\n\n", "\n")
 
 	return true, &result{


### PR DESCRIPTION

This PR fixes an issue where upstream CRDs containing Go template syntax (e.g., `{{ .cluster.name }}` in descriptions) caused Helm templating errors during installation.

**Changes:**
- Modified `pkg/processor/crd/crd.go` to escape all occurrences of `{{` and `}}` in the CRD spec to `{{ "{{" }}` and `{{ "}}" }}`.
- Added regression test in `pkg/processor/crd/crd_test.go`.

**Fixes:** #142