### PR TITLE
[processor/webhook] Replace app's namespace in webhook NamespaceSelectors.

### DIFF
--- a/examples/operator/templates/mutating-webhook-configuration.yaml
+++ b/examples/operator/templates/mutating-webhook-configuration.yaml
@@ -16,6 +16,14 @@ webhooks:
       path: /mutate-ceph-example-com-v1-mycluster
   failurePolicy: Fail
   name: mmycluster.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - namespace-1
+      - '{{ .Release.Namespace }}'
+      - namespace-3
   rules:
   - apiGroups:
     - test.example.com

--- a/examples/operator/templates/validating-webhook-configuration.yaml
+++ b/examples/operator/templates/validating-webhook-configuration.yaml
@@ -17,6 +17,14 @@ webhooks:
       path: /validate-ceph-example-com-v1alpha1-volume
   failurePolicy: Fail
   name: vvolume.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - namespace-1
+      - '{{ .Release.Namespace }}'
+      - namespace-3
   rules:
   - apiGroups:
     - test.example.com

--- a/pkg/processor/webhook/validating.go
+++ b/pkg/processor/webhook/validating.go
@@ -55,6 +55,7 @@ func (w vwh) Process(appMeta helmify.AppMetadata, obj *unstructured.Unstructured
 	for i, whc := range whConf.Webhooks {
 		whc.ClientConfig.Service.Name = appMeta.TemplatedName(whc.ClientConfig.Service.Name)
 		whc.ClientConfig.Service.Namespace = strings.ReplaceAll(whc.ClientConfig.Service.Namespace, appMeta.Namespace(), `{{ .Release.Namespace }}`)
+		mutateNamespaceSelector(appMeta, whc.NamespaceSelector)
 		whConf.Webhooks[i] = whc
 	}
 	webhooks, _ := yaml.Marshal(whConf.Webhooks)

--- a/pkg/processor/webhook/validating_test.go
+++ b/pkg/processor/webhook/validating_test.go
@@ -26,6 +26,14 @@ webhooks:
       path: /validate-ceph-example-com-v1alpha1-volume
   failurePolicy: Fail
   name: vvolume.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - namespace-1
+      - my-operator-system
+      - namespace-3
   rules:
   - apiGroups:
     - test.example.com
@@ -43,7 +51,7 @@ func Test_vwh_Process(t *testing.T) {
 
 	t.Run("processed", func(t *testing.T) {
 		obj := internal.GenerateObj(vwhYaml)
-		processed, _, err := testInstance.Process(&metadata.Service{}, obj)
+		processed, _, err := testInstance.Process(testAppMetaWithNamespace(), obj)
 		assert.NoError(t, err)
 		assert.Equal(t, true, processed)
 	})

--- a/test_data/k8s-operator-kustomize.output
+++ b/test_data/k8s-operator-kustomize.output
@@ -748,6 +748,14 @@ webhooks:
       path: /validate-ceph-example-com-v1alpha1-volume
   failurePolicy: Fail
   name: vvolume.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - namespace-1
+      - my-operator-system
+      - namespace-3
   rules:
   - apiGroups:
     - test.example.com
@@ -835,6 +843,14 @@ webhooks:
       path: /mutate-ceph-example-com-v1-mycluster
   failurePolicy: Fail
   name: mmycluster.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - namespace-1
+      - my-operator-system
+      - namespace-3
   rules:
   - apiGroups:
     - test.example.com


### PR DESCRIPTION
Replace the operator's namespace in the webhook NamespaceSelectors.

This is useful when the controller manager should serve the webhook  for a resource that it need to start. (e.g. corev1.Pod).